### PR TITLE
update matrix strategy

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -13,21 +13,16 @@ env:
   SETUP_BUILDKIT_IMAGE: "moby/buildkit:latest"
 
 jobs:
-  init:
+  prepare:
     runs-on: ubuntu-24.04
-    outputs:
-      includes: ${{ steps.set.outputs.includes }}
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
-        name: Set outputs
-        id: set
+        name: Export BuildKit refs and Bake overrides
         uses: actions/github-script@v7
         with:
           script: |
-            let includes = [];
+            let buildkitRefs = [];
+            let bakeOverrides = [];
             await core.group(`Solve commit from ref`, async () => {
               for (const ref of `${{ inputs.refs }}`.trim().split(/\r?\n/)) {
                 let release = undefined;
@@ -45,29 +40,25 @@ jobs:
                 });
                 if (release) {
                   core.info(`${ref} -> ${release.data.tag_name} -> ${commit.data.sha}`);
+                  buildkitRefs.push(release.data.tag_name);
                 } else {
                   core.info(`${ref} -> ${commit.data.sha}`);
+                  buildkitRefs.push(ref);
                 }
-                includes.push({
-                  ref: release ? release.data.tag_name : ref,
-                  commit: commit.data.sha,
-                });
+                const buildkitRef = release ? release.data.tag_name : ref;
+                const bakeTarget = `buildkit-build-${buildkitRef.replace(/[^a-zA-Z0-9_-]+/g, '-')}`;
+                bakeOverrides.push(`${bakeTarget}.cache-from=type=gha,scope=buildkit-${commit.data.sha}`);
+                bakeOverrides.push(`${bakeTarget}.cache-to=type=gha,scope=buildkit-${commit.data.sha}`);
               }
             });
-            await core.group(`Set includes`, async () => {
-              core.info(JSON.stringify(includes, null, 2));
-              core.setOutput('includes', JSON.stringify(includes ?? []));
+            await core.group(`Export BUILDKIT_REFS`, async () => {
+              core.info(JSON.stringify(buildkitRefs, null, 2));
+              core.exportVariable('BUILDKIT_REFS', buildkitRefs.join(','));
             });
-
-  prepare:
-    runs-on: ubuntu-24.04
-    needs:
-      - init
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJson(needs.init.outputs.includes) }}
-    steps:
+            await core.group(`Export BAKE_OVERRIDES`, async () => {
+              core.info(JSON.stringify(bakeOverrides, null, 2));
+              core.exportVariable('BAKE_OVERRIDES', bakeOverrides.join('\n'));
+            });
       -
         name: Checkout
         uses: actions/checkout@v4
@@ -79,12 +70,10 @@ jobs:
           driver-opts: image=${{ env.SETUP_BUILDKIT_IMAGE }}
           buildkitd-flags: --debug
       -
-        name: Build ${{ matrix.ref }}
+        name: Build base
         uses: docker/bake-action@v5
         with:
           targets: tests-base
+          provenance: false
           set: |
-            buildkit-binaries.cache-from=type=gha,scope=buildkit-${{ matrix.commit }}
-            buildkit-binaries.cache-to=type=gha,scope=buildkit-${{ matrix.commit }}
-        env:
-          BUILDKIT_REF: ${{ matrix.commit }}
+            ${{ env.BAKE_OVERRIDES }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS g
 
 # gobuild is base stage for compiling go/cgo
 FROM golatest AS gobuild-base
-RUN apk add --no-cache file bash clang lld musl-dev pkgconfig git make
+RUN apk add --no-cache file bash clang lld musl-dev pkgconfig git make tree
 COPY --link --from=xx / /
 
 FROM gobuild-base AS registry
@@ -78,7 +78,6 @@ EOF
 FROM scratch AS binaries
 COPY --link --from=gotestsum /out /
 COPY --link --from=registry /out /
-COPY --link --from=buildkit-binaries / /
 
 FROM gobuild-base AS tests-base
 WORKDIR /src
@@ -96,6 +95,8 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 ENV CGO_ENABLED=0
 ENV GOTESTSUM_FORMAT=standard-verbose
 COPY --link --from=binaries / /usr/bin/
+COPY --link --from=buildkit-binaries / /buildkit-binaries
+RUN tree -nh /buildkit-binaries
 
 # tests prepares an image suitable for running tests
 FROM tests-base AS tests

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -2,7 +2,7 @@ variable "BUILDKIT_REPO" {
   default = "moby/buildkit"
 }
 
-variable "BUILDKIT_REF" {
+variable "BUILDKIT_REFS" {
   default = "master"
 }
 
@@ -18,12 +18,38 @@ variable "TEST_COVERAGE" {
   default = null
 }
 
+# https://github.com/docker/buildx/blob/8411a763d99274c7585553f0354a7fdd0df679eb/bake/bake.go#L35
+function "sanitize_target" {
+  params = [in]
+  result = regex_replace(in, "[^a-zA-Z0-9_-]+", "-")
+}
+
+# generate named context for each ref
+function "buildkit_build_contexts" {
+  params = [refs]
+  result = { for ref in split(",", refs) :
+    format("buildkit-build-%s", sanitize_target(ref)) => format("target:buildkit-build-%s", sanitize_target(ref))
+  }
+}
+
+# generate COPY instructions for each ref
+function "buildkit_build_copy_froms" {
+  params = [refs]
+  result = join("\n", [for ref in split(",", refs) :
+    format("COPY --link --from=buildkit-build-%s / /%s", sanitize_target(ref), ref)
+  ])
+}
+
 group "default" {
   targets = ["tests"]
 }
 
-target "buildkit-binaries" {
-  context = "https://github.com/${BUILDKIT_REPO}.git#${BUILDKIT_REF}"
+target "buildkit-build" {
+  name = "buildkit-build-${sanitize_target(ref)}"
+  matrix = {
+    ref = split(",", BUILDKIT_REFS)
+  }
+  context = "https://github.com/${BUILDKIT_REPO}.git#${ref}"
   target = BUILDKIT_TARGET
   args = {
     BUILDKIT_CONTEXT_KEEP_GIT_DIR = 1
@@ -31,11 +57,22 @@ target "buildkit-binaries" {
   }
 }
 
+target "buildkit-binaries" {
+  contexts = buildkit_build_contexts(BUILDKIT_REFS)
+  dockerfile-inline = <<EOT
+FROM scratch
+${buildkit_build_copy_froms(BUILDKIT_REFS)}
+EOT
+}
+
 target "tests-base" {
   contexts = {
     buildkit-binaries = "target:buildkit-binaries"
   }
   target = "tests-base"
+  args = {
+    BUILDKIT_REFS = BUILDKIT_REFS
+  }
   output = ["type=cacheonly"]
 }
 


### PR DESCRIPTION
Currently we are running all tests for each BuildKit ref but we want to run each test for multiple BuildKit refs instead so we make sure it runs on same hardware on GitHub Actions. For that we need to change the matrix logic quite a bit by tweaking bake to join named contexts for multiple refs so we can inject binaries to tests base image.