### PR TITLE
ci: remove gha cache exporter

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -13,20 +13,21 @@ env:
   SETUP_BUILDKIT_IMAGE: "moby/buildkit:latest"
 
 jobs:
-  prepare:
+  run:
     runs-on: ubuntu-24.04
+    env:
+      TESTFLAGS: -v --timeout=30m
+      TEST_IMAGE_BUILD: 0
+      TEST_IMAGE_ID: buildkit-bench
+      BUILDKIT_RUN_COUNT: 3
     steps:
       -
-        name: Export BuildKit refs and Bake overrides
+        name: Export BuildKit refs
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
-            
             let buildkitRefs = [];
-            let bakeCacheFroms = [];
-            let bakeCacheTos = [];
-            let bakeOverrides = [];
             await core.group(`Solve commit from ref`, async () => {
               for (const ref of `${{ inputs.refs }}`.trim().split(/\r?\n/)) {
                 let release = undefined;
@@ -49,88 +50,11 @@ jobs:
                   core.info(`${ref} -> ${commit.data.sha}`);
                   buildkitRefs.push(ref);
                 }
-                const buildkitRef = release ? release.data.tag_name : ref;
-                const bakeTarget = `buildkit-build-${buildkitRef.replace(/[^a-zA-Z0-9_-]+/g, '-')}`;
-                const cacheFrom = `${bakeTarget}.cache-from=type=gha,scope=buildkit-${commit.data.sha}`;
-                const cacheTo = `${bakeTarget}.cache-to=type=gha,scope=buildkit-${commit.data.sha}`;
-                bakeCacheFroms.push(cacheFrom);
-                bakeCacheTos.push(cacheTo);
-                bakeOverrides.push(cacheFrom);
-                bakeOverrides.push(cacheTo);
               }
             });
             await core.group(`Export BUILDKIT_REFS`, async () => {
               core.info(JSON.stringify(buildkitRefs, null, 2));
               core.exportVariable('BUILDKIT_REFS', buildkitRefs.join(','));
-            });
-            await core.group(`Export BAKE_OVERRIDES`, async () => {
-              core.info(JSON.stringify(bakeOverrides, null, 2));
-              core.exportVariable('BAKE_OVERRIDES', bakeOverrides.join('\n'));
-            });
-            await core.group(`Create files for artifact`, async () => {
-              fs.writeFileSync('/tmp/buildkit-refs.txt', buildkitRefs.join(','));
-              fs.writeFileSync('/tmp/bake-overrides-all.txt', bakeOverrides.join('\n'));
-              fs.writeFileSync('/tmp/bake-overrides-cache-froms.txt', bakeCacheFroms.join('\n'));
-              fs.writeFileSync('/tmp/bake-overrides-cache-tos.txt', bakeCacheTos.join('\n'));
-            });
-      -
-        name: Upload config files
-        uses: actions/upload-artifact@v4
-        with:
-          name: config
-          path: |
-            /tmp/buildkit-refs.txt
-            /tmp/bake-overrides*.txt
-      -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          version: ${{ env.SETUP_BUILDX_VERSION }}
-          driver-opts: image=${{ env.SETUP_BUILDKIT_IMAGE }}
-          buildkitd-flags: --debug
-      -
-        name: Build base
-        uses: docker/bake-action@v5
-        with:
-          targets: tests-base
-          provenance: false
-          set: |
-            ${{ env.BAKE_OVERRIDES }}
-
-  test:
-    runs-on: ubuntu-24.04
-    needs:
-      - prepare
-    env:
-      TESTFLAGS: -v --timeout=30m
-      TEST_IMAGE_BUILD: 0
-      TEST_IMAGE_ID: buildkit-bench
-      BUILDKIT_RUN_COUNT: 3
-    steps:
-      -
-        name: Download config files
-        uses: actions/download-artifact@v4
-        with:
-          name: config
-          path: /tmp
-      -
-        name: Export BuildKit refs and Bake overrides
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            await core.group(`Export BUILDKIT_REFS`, async () => {
-              const buildkitRefs = fs.readFileSync('/tmp/buildkit-refs.txt', 'utf-8')
-              core.info(JSON.stringify(buildkitRefs.split(','), null, 2));
-              core.exportVariable('BUILDKIT_REFS', buildkitRefs);
-            });
-            await core.group(`Export BAKE_OVERRIDES`, async () => {
-              const cacheFroms = fs.readFileSync('/tmp/bake-overrides-cache-froms.txt', 'utf-8')
-              core.info(JSON.stringify(cacheFroms.split('\n'), null, 2));
-              core.exportVariable('BAKE_OVERRIDES', cacheFroms);
             });
       -
         name: Checkout
@@ -148,7 +72,6 @@ jobs:
         with:
           targets: tests
           set: |
-            ${{ env.BAKE_OVERRIDES }}
             *.output=type=docker,name=${{ env.TEST_IMAGE_ID }}
       -
         name: Test


### PR DESCRIPTION
relates to #3 

Remove GHA cache exporter for now while working on using registry cache exporter.