### PR TITLE
ci: use gha cache for each ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
           script: |
             const ref = `${{ matrix.ref }}`;
             let buildkitRef;
+            let buildkitCommitSha;
             await core.group(`Solve commit from ref`, async () => {
               let release = undefined;
               if (ref === 'latest') {
@@ -52,6 +53,7 @@ jobs:
                 repo: 'buildkit',
                 ref: release ? release.data.tag_name : ref,
               });
+              buildkitCommitSha = commit.data.sha;
               if (release) {
                 core.info(`${ref} -> ${release.data.tag_name} -> ${commit.data.sha}`);
                 buildkitRef = release.data.tag_name;
@@ -63,6 +65,10 @@ jobs:
             await core.group(`Export BUILDKIT_REF`, async () => {
               core.info(`BUILDKIT_REF=${buildkitRef}`);
               core.exportVariable('BUILDKIT_REF', buildkitRef);
+            });
+            await core.group(`Export BUILDKIT_COMMIT_SHA`, async () => {
+              core.info(`BUILDKIT_COMMIT_SHA=${buildkitCommitSha}`);
+              core.exportVariable('BUILDKIT_COMMIT_SHA', buildkitCommitSha);
             });
       -
         name: Checkout
@@ -81,6 +87,8 @@ jobs:
           targets: tests
           set: |
             *.output=type=docker,name=${{ env.TEST_IMAGE_ID }}
+            *.cache-from=type=gha,scope=buildkit-${{ env.BUILDKIT_COMMIT_SHA }}
+            *.cache-to=type=gha,scope=buildkit-${{ env.BUILDKIT_COMMIT_SHA }}
       -
         name: Test
         run: |


### PR DESCRIPTION
relates to #3 

In previous attempt, we were caching each ref within the same build invocation using named contexts but seems parent targets are not able to solve the blobs. Since #8, we are now building a dedicated sandbox for each ref. Let's see if cache works as expected.