### PR TITLE
ci: cache to registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ env:
   GO_VERSION: 1.22
   SETUP_BUILDX_VERSION: latest
   SETUP_BUILDKIT_IMAGE: moby/buildkit:latest
+  BUILDKIT_CACHE_REPO: ghcr.io/moby/buildkit-bench-cache
 
 jobs:
   prepare:
@@ -50,13 +51,13 @@ jobs:
             const data = JSON.parse(fs.readFileSync('./bin/candidates.json', 'utf8'));
             let includes = [];
             for (const [key, value] of Object.entries(data.refs)) {
-              includes.push({name: key, ref: key, commit: value});
+              includes.push({type: "ref", ref: key, commit: value});
             }
             for (const [key, value] of Object.entries(data.releases)) {
-              includes.push({name: key, ref: key, commit: value});
+              includes.push({type: "release", ref: key, commit: value});
             }
             for (const [key, value] of Object.entries(data.commits)) {
-              includes.push({name: key, ref: value, commit: value});
+              includes.push({type: "commit", ref: value, commit: value});
             }
             core.info(JSON.stringify(includes, null, 2));
             core.setOutput('includes', JSON.stringify(includes ?? []));
@@ -76,14 +77,6 @@ jobs:
       BUILDKIT_RUN_COUNT: 3
     steps:
       -
-        name: Export BuildKit ref for ${{ matrix.name }}
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const ref = `${{ matrix.ref }}`;
-            core.info(`BUILDKIT_REF=${ref}`);
-            core.exportVariable('BUILDKIT_REF', ref);
-      -
         name: Checkout
         uses: actions/checkout@v4
       -
@@ -94,12 +87,26 @@ jobs:
           driver-opts: image=${{ env.SETUP_BUILDKIT_IMAGE }}
           buildkitd-flags: --debug
       -
+        name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
         name: Build test image
         uses: docker/bake-action@v5
         with:
           targets: tests
           set: |
             *.output=type=docker,name=${{ env.TEST_IMAGE_ID }}
+            *.cache-to=type=registry,ignore-error=true,ref=${{ env.BUILDKIT_CACHE_REPO }}:${{ matrix.commit }}
+            *.cache-to=type=registry,ignore-error=true,ref=${{ env.BUILDKIT_CACHE_REPO }}:${{ matrix.type }}-${{ matrix.ref }}
+        env:
+          BUILDKIT_REF: ${{ matrix.ref }}
+          BUILDKIT_REF_TYPE: ${{ matrix.type }}
+          BUILDKIT_REF_COMMIT: ${{ matrix.commit }}
       -
         name: Test
         run: |

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -2,8 +2,20 @@ variable "BUILDKIT_REPO" {
   default = "moby/buildkit"
 }
 
+variable "BUILDKIT_CACHE_REPO" {
+  default = "ghcr.io/moby/buildkit-bench-cache"
+}
+
 variable "BUILDKIT_REF" {
   default = "master"
+}
+
+variable "BUILDKIT_REF_TYPE" {
+  default = "ref"
+}
+
+variable "BUILDKIT_REF_COMMIT" {
+  default = null
 }
 
 variable "BUILDKIT_TARGET" {
@@ -14,7 +26,16 @@ group "default" {
   targets = ["tests"]
 }
 
+target "_common" {
+  cache-from = [
+    "type=registry,ref=${BUILDKIT_CACHE_REPO}:${BUILDKIT_REF_TYPE}-${BUILDKIT_REF}",
+    "${BUILDKIT_REF_COMMIT != null ? "type=registry,ref=${BUILDKIT_CACHE_REPO}:${BUILDKIT_REF_COMMIT}" : ""}"
+  ]
+  cache-to = ["type=inline"]
+}
+
 target "buildkit-binaries" {
+  inherits = ["_common"]
   context = "https://github.com/${BUILDKIT_REPO}.git#${BUILDKIT_REF}"
   target = BUILDKIT_TARGET
   args = {
@@ -24,6 +45,7 @@ target "buildkit-binaries" {
 }
 
 target "tests-base" {
+  inherits = ["_common"]
   contexts = {
     buildkit-binaries = "target:buildkit-binaries"
   }


### PR DESCRIPTION
Push cache to GHCR registry instead of GHA: https://github.com/moby/buildkit-bench/pkgs/container/buildkit-bench-cache

Edit: We have the same issue https://github.com/moby/buildkit-bench/issues/3 for registry cache: https://github.com/moby/buildkit-bench/actions/runs/10528892455/job/29175679716#step:5:424 so this might be smth upstream. Will test with a small repro.