### PR TITLE
build each ref and merge them in tests image

### DIFF
--- a/.github/workflows/.buildkit-binaries.yml
+++ b/.github/workflows/.buildkit-binaries.yml
@@ -1,0 +1,94 @@
+# reusable workflow
+name: .buildkit-binaries
+
+on:
+  workflow_call:
+    inputs:
+      refs:
+        type: string
+        default: master
+      last_days:
+        type: string
+        default: 7
+      last_releases:
+        type: string
+        default: 3
+      artifact_key:
+        type: string
+        default: buildkit-binaries
+
+env:
+  GO_VERSION: 1.22
+  SETUP_BUILDX_VERSION: latest
+  SETUP_BUILDKIT_IMAGE: moby/buildkit:latest
+
+jobs:
+  prepare:
+    runs-on: ubuntu-24.04
+    outputs:
+      includes: ${{ steps.set.outputs.includes }}
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      -
+        name: Set includes
+        id: set
+        run: |
+          go run -mod=vendor ./cmd/refcandidates \
+            --refs ${{ inputs.refs }} \
+            --last-days ${{ inputs.last_days }} \
+            --last-releases ${{ inputs.last_releases }} \
+            --gha-output includes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build:
+    runs-on: ubuntu-24.04
+    needs:
+      - prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.prepare.outputs.includes) }}
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          version: ${{ env.SETUP_BUILDX_VERSION }}
+          driver-opts: image=${{ env.SETUP_BUILDKIT_IMAGE }}
+          buildkitd-flags: --debug
+      -
+        name: Build
+        uses: docker/bake-action@v5
+        with:
+          targets: buildkit-build
+          provenance: false
+          set: |
+            *.output=./bin/buildkit-binaries/${{ matrix.name }}
+            *.cache-from=type=gha,scope=buildkit-binaries-${{ matrix.commit }}
+            *.cache-to=type=gha,scope=buildkit-binaries-${{ matrix.commit }}
+        env:
+          BUILDKIT_REFS: ${{ matrix.ref }}
+      -
+        # https://github.com/actions/upload-artifact/?tab=readme-ov-file#permission-loss
+        name: Tar binaries
+        working-directory: ./bin/buildkit-binaries
+        run: tar -czvf ../binaries-${{ matrix.name }}.tar.gz *
+      -
+        name: Upload binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact_key }}-${{ matrix.name }}
+          path: ./bin/binaries-${{ matrix.name }}.tar.gz
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,47 +12,23 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: 1.22
   SETUP_BUILDX_VERSION: latest
   SETUP_BUILDKIT_IMAGE: moby/buildkit:latest
-  CANDIDATES_REFS: master
-  CANDIDATES_LAST_DAYS: 7
-  CANDIDATES_LAST_RELEASES: 3
 
 jobs:
-  prepare:
-    runs-on: ubuntu-24.04
-    outputs:
-      includes: ${{ steps.set.outputs.includes }}
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
-        name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-      -
-        name: Set includes
-        id: set
-        run: |
-          go run -mod=vendor ./cmd/refcandidates \
-            --refs ${{ env.CANDIDATES_REFS }} \
-            --last-days ${{ env.CANDIDATES_LAST_DAYS }} \
-            --last-releases ${{ env.CANDIDATES_LAST_RELEASES }} \
-            --gha-output includes
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  buildkit-binaries:
+    uses: ./.github/workflows/.buildkit-binaries.yml
+    secrets: inherit
+    with:
+      refs: master
+      last_days: 7
+      last_releases: 3
+      artifact_key: buildkit-binaries
 
   test:
     runs-on: ubuntu-24.04
     needs:
-      - prepare
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJson(needs.prepare.outputs.includes) }}
+      - buildkit-binaries
     env:
       TEST_FLAGS: -v --timeout=30m
       TEST_IMAGE_BUILD: 0
@@ -62,6 +38,21 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v4
+      -
+        name: Download binaries
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/buildkit-binaries
+          pattern: buildkit-binaries-*
+          merge-multiple: true
+      -
+        name: Extract binaries
+        run: |
+          mkdir -p ./bin/buildkit-binaries
+          for f in "/tmp/buildkit-binaries"/*.tar.gz; do
+            (set -x ; tar -xzvf "$f" -C ./bin/buildkit-binaries)
+          done
+          tree -nph ./bin/buildkit-binaries
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -74,10 +65,10 @@ jobs:
         uses: docker/bake-action@v5
         with:
           targets: tests
+          provenance: false
           set: |
+            *.contexts.buildkit-binaries=./bin/buildkit-binaries
             *.output=type=docker,name=${{ env.TEST_IMAGE_ID }}
-        env:
-          BUILDKIT_REF: ${{ matrix.ref }}
       -
         name: Test
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,9 +71,8 @@ RUN curl -Ls https://raw.githubusercontent.com/moby/moby/v25.0.1/hack/dind > /do
 ENTRYPOINT ["/docker-entrypoint.sh"]
 ENV CGO_ENABLED=0
 COPY --link --from=binaries / /usr/bin/
-ARG BUILDKIT_REF=master
-COPY --link --from=buildkit-binaries / /buildkit-binaries/$BUILDKIT_REF
-RUN tree -nh /buildkit-binaries
+COPY --link --from=buildkit-binaries / /buildkit-binaries
+RUN tree -nph /buildkit-binaries
 
 # tests prepares an image suitable for running tests
 FROM tests-base AS tests


### PR DESCRIPTION
In https://github.com/moby/buildkit-bench/pull/8 we were building each sandbox for a specific ref and run them also independently. This is an issue as we want to run tests for all refs within the same public GitHub Runner to avoid incorrect bench as hardware is not the same across their infrastructure.

With this change we are still building each ref on a dedicated runner to reduce build time but merge them within the sandbox. This also allows us to workaround the cache issue when using names contexts (#3).