### PR TITLE
keep track of buildkit ref date for each benchmark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,7 @@ jobs:
           TEST_FLAGS: -bench=${{ matrix.test }} ${{ env.TEST_FLAGS }}
           TEST_BENCH_RUN: ${{ matrix.count }}
           TEST_BENCH_TIME: ${{ matrix.benchtime }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Result
         run: |

--- a/hack/test
+++ b/hack/test
@@ -9,7 +9,9 @@ set -eu -o pipefail
 : "${TEST_BENCH_RUN=1}"
 : "${TEST_BENCH_TIME=1s}"
 
+: "${BUILDKIT_REPO=moby/buildkit}"
 : "${BUILDKIT_REF_RANDOM=}"
+: "${GITHUB_TOKEN=}"
 
 gotestArgs="-json -mod=vendor"
 if [ -n "$TEST_BENCH_TIME" ]; then
@@ -37,8 +39,10 @@ docker run --rm --privileged \
   -v /tmp \
   -v $testOutputDir:/testout \
   --volumes-from=$cacheVolume \
-  -e BUILDKIT_REF_RANDOM \
   -e TEST_BENCH_RUN \
   -e REGISTRY_MIRROR_DIR=/root/.cache/registry \
+  -e BUILDKIT_REPO=$BUILDKIT_REPO \
+  -e BUILDKIT_REF_RANDOM=$BUILDKIT_REF_RANDOM \
+  -e GITHUB_TOKEN \
   $TEST_IMAGE_ID \
   sh -c "go test -benchmem $gotestArgs ${TEST_FLAGS:--v} ./... | gotestmetrics parse --output /testout/gotestoutput.json"

--- a/test/binary_test.go
+++ b/test/binary_test.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/moby/buildkit-bench/util/testutil"
 	"github.com/stretchr/testify/require"
@@ -41,7 +42,9 @@ func testBinaryVersion(t *testing.T, sb testutil.Sandbox) {
 func benchmarkBinaryVersion(b *testing.B, sb testutil.Sandbox) {
 	for i := 0; i < b.N; i++ {
 		buildkitdPath := path.Join(sb.BinsDir(), sb.Name(), "buildkitd")
+		start := time.Now()
 		require.NoError(b, exec.Command(buildkitdPath, "--version").Run())
+		testutil.ReportMetricDuration(b, time.Since(start))
 	}
 }
 
@@ -49,6 +52,5 @@ func benchmarkBinarySize(b *testing.B, sb testutil.Sandbox) {
 	buildkitdPath := path.Join(sb.BinsDir(), sb.Name(), "buildkitd")
 	fi, err := os.Stat(buildkitdPath)
 	require.NoError(b, err)
-	b.ResetTimer()
-	testutil.ReportMetric(b, float64(fi.Size()), "bytes")
+	testutil.ReportMetric(b, float64(fi.Size()), testutil.MetricBytes)
 }

--- a/util/testutil/metric.go
+++ b/util/testutil/metric.go
@@ -1,0 +1,23 @@
+package testutil
+
+import (
+	"testing"
+	"time"
+)
+
+type MetricUnit string
+
+const (
+	MetricBytes MetricUnit = "bytes"
+
+	metricDuration     MetricUnit = "duration"
+	metricRefTimestamp MetricUnit = "ref_timestamp"
+)
+
+func ReportMetric(b *testing.B, value float64, unit MetricUnit) {
+	b.ReportMetric(value, string(unit))
+}
+
+func ReportMetricDuration(b *testing.B, value time.Duration) {
+	ReportMetric(b, float64(value.Nanoseconds()), metricDuration)
+}

--- a/util/testutil/ref.go
+++ b/util/testutil/ref.go
@@ -3,29 +3,50 @@ package testutil
 import (
 	"context"
 	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/moby/buildkit-bench/util/github"
+	"github.com/moby/buildkit/util/bklog"
+	"github.com/pkg/errors"
 )
 
-var binsDir = "/buildkit-binaries"
+var (
+	binsDir      = "/buildkit-binaries"
+	githubClient *github.Client
+)
 
 func init() {
+	var err error
 	if v := os.Getenv("BUILDKIT_BINS_DIR"); v != "" {
 		binsDir = v
 	}
-	if refs, err := getRefs(binsDir); err == nil {
-		for _, ref := range refs {
-			Register(&Ref{ID: ref})
+	if repo := os.Getenv("BUILDKIT_REPO"); repo != "" {
+		if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+			githubClient, err = github.NewClient(repo, token)
+			if err != nil {
+				bklog.L.Errorf("error creating github client: %v", err)
+			}
 		}
-	} else {
-		panic(err)
+	}
+	for _, ref := range getRefs(binsDir) {
+		Register(ref)
 	}
 }
 
 type Ref struct {
-	ID string
+	id            string
+	committerDate time.Time
 }
 
 func (c *Ref) Name() string {
-	return c.ID
+	return c.id
+}
+
+func (c *Ref) CommitterDate() time.Time {
+	return c.committerDate
 }
 
 func (c *Ref) New(ctx context.Context) (b Backend, cl func() error, err error) {
@@ -42,15 +63,42 @@ func (c *Ref) New(ctx context.Context) (b Backend, cl func() error, err error) {
 	return Backend{}, cl, nil
 }
 
-func getRefs(dir string) ([]string, error) {
-	var refs []string
+func getRefs(dir string) []*Ref {
+	var refs []*Ref
 	entries, err := os.ReadDir(dir)
-	if err == nil {
-		for _, entry := range entries {
-			if entry.IsDir() {
-				refs = append(refs, entry.Name())
-			}
+	if err != nil {
+		return refs
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if ref, err := getRef(dir, entry); err == nil {
+			refs = append(refs, ref)
 		}
 	}
-	return refs, nil
+	return refs
+}
+
+func getRef(dir string, entry os.DirEntry) (*Ref, error) {
+	ref := &Ref{id: entry.Name()}
+	buildkitdPath := path.Join(dir, entry.Name(), "buildkitd")
+	output, err := exec.Command(buildkitdPath, "--version").Output()
+	if err != nil {
+		return ref, errors.Wrap(err, "error running buildkitd --version")
+	}
+	versionParts := strings.Fields(string(output))
+	// buildkitd github.com/moby/buildkit v0.9.3 8d2625494a6a3d413e3d875a2ff7dd9b1ed1b1a9
+	if len(versionParts) < 4 {
+		return ref, errors.Errorf("unexpected version output: %s", string(output))
+	}
+	if githubClient == nil {
+		return ref, nil
+	}
+	cm, err := githubClient.GetCommit(versionParts[3])
+	if err != nil {
+		return ref, errors.Wrap(err, "error getting github commit")
+	}
+	ref.committerDate = cm.Commit.Committer.Date
+	return ref, nil
 }


### PR DESCRIPTION
For each benchmark set ref timestamp as metric. This is to help sorting benchmarks results when merging them and generating graphs for #13.