### PR TITLE
don't report ref_timestamp as metric

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ env:
   SETUP_BUILDKIT_IMAGE: moby/buildkit:latest
   BUILDKIT_REPO: moby/buildkit
   BUILDKIT_ARTIFACT_KEY: buildkit-binaries
+  CANDIDATES_REFS: master
+  CANDIDATES_LAST_DAYS: 7
+  CANDIDATES_LAST_RELEASES: 3
 
 jobs:
   # limitation to using envs in a reusable workflow input
@@ -26,6 +29,9 @@ jobs:
     outputs:
       BUILDKIT_REPO: ${{ env.BUILDKIT_REPO }}
       BUILDKIT_ARTIFACT_KEY: ${{ env.BUILDKIT_ARTIFACT_KEY }}
+      CANDIDATES_REFS: ${{ env.CANDIDATES_REFS }}
+      CANDIDATES_LAST_DAYS: ${{ env.CANDIDATES_LAST_DAYS }}
+      CANDIDATES_LAST_RELEASES: ${{ env.CANDIDATES_LAST_RELEASES }}
     steps:
       - run: "true"
 
@@ -56,9 +62,9 @@ jobs:
     secrets: inherit
     with:
       repo: ${{ needs.get-env.outputs.BUILDKIT_REPO }}
-      refs: master
-      last_days: 7
-      last_releases: 3
+      refs: ${{ needs.get-env.outputs.CANDIDATES_REFS }}
+      last_days: ${{ needs.get-env.outputs.CANDIDATES_LAST_DAYS }}
+      last_releases: ${{ needs.get-env.outputs.CANDIDATES_LAST_RELEASES }}
       artifact_key: ${{ needs.get-env.outputs.BUILDKIT_ARTIFACT_KEY }}
 
   test:

--- a/util/testutil/metric.go
+++ b/util/testutil/metric.go
@@ -8,10 +8,8 @@ import (
 type MetricUnit string
 
 const (
-	MetricBytes MetricUnit = "bytes"
-
-	metricDuration     MetricUnit = "duration"
-	metricRefTimestamp MetricUnit = "ref_timestamp"
+	MetricBytes    MetricUnit = "bytes"
+	MetricDuration MetricUnit = "duration"
 )
 
 func ReportMetric(b *testing.B, value float64, unit MetricUnit) {
@@ -19,5 +17,5 @@ func ReportMetric(b *testing.B, value float64, unit MetricUnit) {
 }
 
 func ReportMetricDuration(b *testing.B, value time.Duration) {
-	ReportMetric(b, float64(value.Nanoseconds()), metricDuration)
+	ReportMetric(b, float64(value.Nanoseconds()), MetricDuration)
 }

--- a/util/testutil/run.go
+++ b/util/testutil/run.go
@@ -183,10 +183,6 @@ func Run(tb testing.TB, runners []Runner, opt ...TestOpt) {
 							sb, _, err := newSandbox(ctx, br, mv)
 							require.NoError(tb, err)
 
-							if b, ok := tb.(*testing.B); ok && !br.CommitterDate().IsZero() {
-								ReportMetric(b, float64(br.CommitterDate().Unix()), metricRefTimestamp)
-							}
-
 							runner.Run(tb, sb)
 						})
 						require.True(tb, ok)


### PR DESCRIPTION
follow-up https://github.com/moby/buildkit-bench/pull/29#issue-2494038674

Ref timestamp is just used to manage sorting of data points in generated graphs. We can do that directly during merge.