### PR TITLE
fix benchmarkPackageSize missing

### DIFF
--- a/test/binary_test.go
+++ b/test/binary_test.go
@@ -23,6 +23,7 @@ func BenchmarkBinary(b *testing.B) {
 	testutil.Run(b, testutil.BenchFuncs(
 		benchmarkBinaryVersion,
 		benchmarkBinarySize,
+		benchmarkPackageSize,
 	))
 }
 


### PR DESCRIPTION
relates to https://github.com/moby/buildkit-bench/actions/runs/10616869615/job/29428495239#step:7:139

```
goos: linux
goarch: amd64
pkg: github.com/moby/buildkit-bench/test
cpu: AMD EPYC 7763 64-Core Processor                
BenchmarkBinary
PASS
ok  	github.com/moby/buildkit-bench/test	0.635s
?   	github.com/moby/buildkit-bench/util/candidates	[no test files]
?   	github.com/moby/buildkit-bench/util/github	[no test files]
?   	github.com/moby/buildkit-bench/util/gotest	[no test files]
?   	github.com/moby/buildkit-bench/util/gotest/benchmark	[no test files]
?   	github.com/moby/buildkit-bench/util/testutil	[no test files]
+ docker rm -v buildkit-bench-cache
```

Benchmark didn't run, we should probably error out in this case.