### PR TITLE
ci: use docker driver to build sandbox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           version: ${{ env.SETUP_BUILDX_VERSION }}
-          driver-opts: image=${{ env.SETUP_BUILDKIT_IMAGE }}
-          buildkitd-flags: --debug
+          driver: docker
       -
         name: Build test image
         uses: docker/bake-action@v5


### PR DESCRIPTION
reduce build time for test image when loading to docker store