### PR TITLE
test: switch from buildctl to buildx 0.17.0 as client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ARG GO_VERSION=1.22
 ARG ALPINE_VERSION=3.20
 ARG XX_VERSION=1.4.0
 
+ARG BUILDX_VERSION=0.17.0
 ARG REGISTRY_VERSION=v2.8.3
 
 # named contexts
@@ -12,6 +13,9 @@ FROM scratch AS tests-results
 
 # xx is a helper for cross-compilation
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
+
+# buildx client
+FROM docker/buildx-bin:${BUILDX_VERSION} AS buildx
 
 # go base image
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS golatest
@@ -71,6 +75,7 @@ COPY --from=tests-gen-run /tmp/benchmarks.html /index.html
 
 FROM scratch AS binaries
 COPY --link --from=registry /out /
+COPY --link --from=buildx /buildx /
 COPY --link --from=gotestmetrics /usr/bin/gotestmetrics /
 
 FROM gobuild-base AS tests-base

--- a/test/build_test.go
+++ b/test/build_test.go
@@ -41,10 +41,7 @@ COPY --from=base /etc/bar /bar
 	)
 	b.ResetTimer()
 	b.StartTimer()
-	out, err := buildCmd(sb, withDir(dir), withArgs(
-		"--local=context=.",
-		"--local=dockerfile=.",
-	))
+	out, err := buildxBuildCmd(sb, withArgs(dir))
 	b.StopTimer()
 	require.NoError(b, err, out)
 }
@@ -62,11 +59,7 @@ RUN --mount=type=secret,id=SECRET cat /run/secrets/SECRET
 	)
 	b.ResetTimer()
 	b.StartTimer()
-	out, err := buildCmd(sb, withDir(dir), withArgs(
-		"--local=context=.",
-		"--local=dockerfile=.",
-		"--secret=id=SECRET,src=secret.txt",
-	))
+	out, err := buildxBuildCmd(sb, withDir(dir), withArgs("--secret=id=SECRET,src=secret.txt", "."))
 	b.StopTimer()
 	require.NoError(b, err, out)
 }
@@ -74,9 +67,9 @@ RUN --mount=type=secret,id=SECRET cat /run/secrets/SECRET
 func benchmarkBuildRemoteBuildme(b *testing.B, sb testutil.Sandbox) {
 	b.ResetTimer()
 	b.StartTimer()
-	out, err := buildCmd(sb, withArgs(
-		"--opt=context=https://github.com/dvdksn/buildme.git#eb6279e0ad8a10003718656c6867539bd9426ad8",
-		"--opt=build-arg:BUILDKIT_SYNTAX=docker/dockerfile:1.9.0", // pin dockerfile syntax
+	out, err := buildxBuildCmd(sb, withArgs(
+		"--build-arg=BUILDKIT_SYNTAX=docker/dockerfile:1.9.0",
+		"https://github.com/dvdksn/buildme.git#eb6279e0ad8a10003718656c6867539bd9426ad8",
 	))
 	b.StopTimer()
 	require.NoError(b, err, out)
@@ -104,9 +97,9 @@ func buildBreaker(b *testing.B, sb testutil.Sandbox, n int) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			out, err := buildCmd(sb, withArgs(
-				"--opt=context=https://github.com/dvdksn/buildme.git#eb6279e0ad8a10003718656c6867539bd9426ad8",
-				"--opt=build-arg:BUILDKIT_SYNTAX=docker/dockerfile:1.9.0", // pin dockerfile syntax
+			out, err := buildxBuildCmd(sb, withArgs(
+				"--build-arg=BUILDKIT_SYNTAX=docker/dockerfile:1.9.0",
+				"https://github.com/dvdksn/buildme.git#eb6279e0ad8a10003718656c6867539bd9426ad8",
 			))
 			require.NoError(b, err, out)
 		}()

--- a/test/buildx_test.go
+++ b/test/buildx_test.go
@@ -1,0 +1,21 @@
+package test
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/moby/buildkit-bench/util/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildx(t *testing.T) {
+	testutil.Run(t, testutil.TestFuncs(
+		testBuildxVersion,
+	))
+}
+
+func testBuildxVersion(t *testing.T, sb testutil.Sandbox) {
+	output, err := exec.Command("buildx", "version").Output()
+	require.NoError(t, err)
+	t.Log(string(output))
+}

--- a/util/testutil/run.go
+++ b/util/testutil/run.go
@@ -38,6 +38,9 @@ func init() {
 type Backend interface {
 	Address() string
 	DebugAddress() string
+	ExtraEnv() []string
+	BuildxDir() string
+	BuilderName() string
 }
 
 type Sandbox interface {


### PR DESCRIPTION
Use Buildx as client instead of buildctl.

As follow-up we could set `--metadata-file` https://docs.docker.com/reference/cli/docker/buildx/build/#metadata-file and `BUILDX_METADATA_PROVENANCE` to `max` so we can have details metrics we could use. This will not work for BuildKit versions that don't support history API though.