### PR TITLE
test: set default benchtime to 0.01s

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ TEST_BENCH_REGEXP=/BenchmarkBuildLocal$ make test
 # run all benchmarks 3 times (default 1)
 TEST_BENCH_RUN=3 make test
 
-# run enough iterations of each benchmark to take 2s (default 1s)
+# run enough iterations of each benchmark to take 2s (default 0.01s)
 TEST_BENCH_TIME=2s make test
 
 # run all with master, v0.9.3 and v0.16.0 git references

--- a/hack/test
+++ b/hack/test
@@ -60,5 +60,5 @@ fi
     -e BUILDKIT_REF_RANDOM=$BUILDKIT_REF_RANDOM \
     -e REGISTRY_MIRROR_DIR=/root/.cache/registry \
     $TEST_IMAGE_ID \
-    sh -c "go test -bench=${TEST_BENCH_REGEXP:-.} -benchtime=${TEST_BENCH_TIME:-1s} -benchmem -json -mod=vendor ${TEST_FLAGS:--v} ${TEST_PKG:-./test/...} | gotestmetrics parse --output /testout/gotestoutput.json"
+    sh -c "go test -bench=${TEST_BENCH_REGEXP:-.} -benchtime=${TEST_BENCH_TIME:-0.01s} -benchmem -json -mod=vendor ${TEST_FLAGS:--v} ${TEST_PKG:-./test/...} | gotestmetrics parse --output /testout/gotestoutput.json"
 )

--- a/testconfig.yml
+++ b/testconfig.yml
@@ -1,6 +1,6 @@
 defaults:
   count: 3
-  benchtime: 1s
+  benchtime: 0.01s
 
 runs:
   BenchmarkBuild:
@@ -15,6 +15,7 @@ runs:
     BenchmarkBuildLocalSecret:
       description: Local build with secret
       count: 4
+      benchtime: 1s
       metrics:
         duration:
           description: Time (s)
@@ -22,6 +23,7 @@ runs:
     BenchmarkBuildRemoteBuildme:
       description: Remote build github.com/dvdksn/buildme
       count: 4
+      benchtime: 1s
       metrics:
         duration:
           description: Time (s)
@@ -29,6 +31,7 @@ runs:
     BenchmarkBuildBreaker16:
       description: Build breaker 16x
       count: 3
+      benchtime: 1s
       metrics:
         duration:
           description: Time (s)
@@ -36,6 +39,7 @@ runs:
     BenchmarkBuildBreaker32:
       description: Build breaker 32x
       count: 4
+      benchtime: 1s
       metrics:
         duration:
           description: Time (s)
@@ -43,6 +47,7 @@ runs:
     BenchmarkBuildBreaker64:
       description: Build breaker 64x
       count: 4
+      benchtime: 1s
       metrics:
         duration:
           description: Time (s)
@@ -50,6 +55,7 @@ runs:
     BenchmarkBuildBreaker128:
       description: Build breaker 128x
       count: 4
+      benchtime: 1s
       metrics:
         duration:
           description: Time (s)
@@ -67,6 +73,7 @@ runs:
     BenchmarkDaemonSize:
       description: Daemon binary size
       count: 1
+      benchtime: 1s
       metrics:
         bytes:
           description: Size (bytes)
@@ -77,6 +84,7 @@ runs:
     BenchmarkPackageSize:
       description: Package size
       count: 1
+      benchtime: 1s
       metrics:
         bytes:
           description: Size (bytes)


### PR DESCRIPTION
relates to https://github.com/golang/go/issues/27217#issuecomment-453829330