### PR TITLE
remove BUILDKIT_DEBUG from buildkit-build

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -54,9 +54,6 @@ target "buildkit-build" {
   }
   context = "https://github.com/${BUILDKIT_REPO}.git#${ref}"
   target = BUILDKIT_TARGET
-  args = {
-    BUILDKIT_DEBUG = 1
-  }
   cache-from = ["type=registry,ref=${BUILDKIT_CACHE_REPO}:bkbins-${ref}"]
   cache-to = ["type=inline"]
 }


### PR DESCRIPTION
Not sure why this was set but it can't be as only
versions starting from v0.13.0 understand this ARG.

Release binaries also do not have this enabled so
should give more consistent results with production.