### PR TITLE
github: setup-qemu for more realistic test environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,9 @@ jobs:
           version: ${{ env.SETUP_BUILDX_VERSION }}
           driver: docker
       -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
         name: Build test image
         uses: docker/bake-action@v5
         with:


### PR DESCRIPTION
Because no emulators are installed in kernel many codepaths are skipped and bugs in typical environment can go undetected.

Local run:

```
BenchmarkBuild/BenchmarkBuildBreaker64/ref=v0.12.0/run=1-8         	       1	16970149777 ns/op	 2942184 B/op	    5658 allocs/op
BenchmarkBuild/BenchmarkBuildBreaker64/ref=v0.12.0/run=2
BenchmarkBuild/BenchmarkBuildBreaker64/ref=v0.12.0/run=2-8         	       1	16661650068 ns/op	 2437440 B/op	    5549 allocs/op
BenchmarkBuild/BenchmarkBuildBreaker64/ref=v0.13.0/run=1
BenchmarkBuild/BenchmarkBuildBreaker64/ref=v0.13.0/run=1-8         	       1	16414651131 ns/op	 2582616 B/op	    5552 allocs/op
BenchmarkBuild/BenchmarkBuildBreaker64/ref=v0.13.0/run=2
BenchmarkBuild/BenchmarkBuildBreaker64/ref=v0.13.0/run=2-8         	       1	16919238467 ns/op	 2694360 B/op	    5556 allocs/op
BenchmarkBuild/BenchmarkBuildBreaker64/ref=v0.14.0/run=1
BenchmarkBuild/BenchmarkBuildBreaker64/ref=v0.14.0/run=1-8                     1	14266037022 ns/op	 2237432 B/op	    5584 allocs/op
BenchmarkBuild/BenchmarkBuildBreaker64/ref=v0.14.0/run=2
BenchmarkBuild/BenchmarkBuildBreaker64/ref=v0.14.0/run=2-8         	       1	14390713294 ns/op	 2231088 B/op	    5563 allocs/op
BenchmarkBuild/BenchmarkBuildBreaker64/ref=v0.15.2/run=1
BenchmarkBuild/BenchmarkBuildBreaker64/ref=v0.15.2/run=1-8         	       1	14126009714 ns/op	 2227792 B/op	    5541 allocs/op
BenchmarkBuild/BenchmarkBuildBreaker64/ref=v0.15.2/run=2
BenchmarkBuild/BenchmarkBuildBreaker64/ref=v0.15.2/run=2-8         	       1	14341318725 ns/op	 2224408 B/op	    5539 allocs/op
BenchmarkDaemon
```