### PR TITLE
Enable creating image as part of the test

### DIFF
--- a/test/build_test.go
+++ b/test/build_test.go
@@ -103,6 +103,7 @@ func buildBreaker(b *testing.B, sb testutil.Sandbox, n int) {
 			defer wg.Done()
 			out, err := buildxBuildCmd(sb, withArgs(
 				"--build-arg=BUILDKIT_SYNTAX="+dockerfileImagePin,
+				"-o", "type=image",
 				"https://github.com/dvdksn/buildme.git#eb6279e0ad8a10003718656c6867539bd9426ad8",
 			))
 			require.NoError(b, err, out)


### PR DESCRIPTION
Make sure tested codepath is longer and doesn't
end without trying to export the build result.

Local run:
```
BenchmarkBuild/BenchmarkBuildBreaker64/ref=v0.12.0/run=1
BenchmarkBuild/BenchmarkBuildBreaker64/ref=v0.12.0/run=1-8         	       1	80665038297 ns/op	 3005320 B/op	    5638 allocs/op
BenchmarkBuild/BenchmarkBuildBreaker64/ref=v0.12.0/run=2
BenchmarkBuild/BenchmarkBuildBreaker64/ref=v0.12.0/run=2-8         	       1	17462715767 ns/op	 2784432 B/op	    5266 allocs/op
BenchmarkBuild/BenchmarkBuildBreaker64/ref=v0.13.0/run=1
BenchmarkBuild/BenchmarkBuildBreaker64/ref=v0.13.0/run=1-8         	       1	19406766775 ns/op	 2808448 B/op	    5564 allocs/op
BenchmarkBuild/BenchmarkBuildBreaker64/ref=v0.13.0/run=2
BenchmarkBuild/BenchmarkBuildBreaker64/ref=v0.13.0/run=2-8         	       1	18879301191 ns/op	 2817800 B/op	    5598 allocs/op
BenchmarkBuild/BenchmarkBuildBreaker64/ref=v0.14.0/run=1
BenchmarkBuild/BenchmarkBuildBreaker64/ref=v0.14.0/run=1-8         	       1	16501887018 ns/op	 2286864 B/op	    5570 allocs/op
BenchmarkBuild/BenchmarkBuildBreaker64/ref=v0.14.0/run=2
BenchmarkBuild/BenchmarkBuildBreaker64/ref=v0.14.0/run=2-8         	       1	16100322279 ns/op	 2283176 B/op	    5561 allocs/op
BenchmarkBuild/BenchmarkBuildBreaker64/ref=v0.15.2/run=1
BenchmarkBuild/BenchmarkBuildBreaker64/ref=v0.15.2/run=1-8         	       1	16594337035 ns/op	 2285336 B/op	    5559 allocs/op
BenchmarkBuild/BenchmarkBuildBreaker64/ref=v0.15.2/run=2
BenchmarkBuild/BenchmarkBuildBreaker64/ref=v0.15.2/run=2-8         	       1	16261203568 ns/op	 2281744 B/op	    5567 allocs/op
BenchmarkDaemon
```