### PR TITLE
test: run a single iteration for benchmark by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ TEST_BENCH_REGEXP=/BenchmarkBuildLocal$ make test
 # run all benchmarks 3 times (default 1)
 TEST_BENCH_RUN=3 make test
 
-# run enough iterations of each benchmark to take 2s (default 0.01s)
-TEST_BENCH_TIME=2s make test
+# run 5 iterations of each benchmark (default 1x)
+TEST_BENCH_TIME=5x make test
 
 # run all with master, v0.9.3 and v0.16.0 git references
 BUILDKIT_REFS=master,v0.9.3,v0.16.0 make test

--- a/hack/test
+++ b/hack/test
@@ -62,5 +62,5 @@ fi
     -e BUILDKIT_REF_RANDOM=$BUILDKIT_REF_RANDOM \
     -e REGISTRY_MIRROR_DIR=/root/.cache/registry \
     $TEST_IMAGE_ID \
-    sh -c "go test -bench=${TEST_BENCH_REGEXP:-.} -benchtime=${TEST_BENCH_TIME:-0.01s} -benchmem -json -mod=vendor ${TEST_FLAGS:--v} ${TEST_PKG:-./test/...} | gotestmetrics parse --output $TEST_OUT_DIR/gotestoutput.json"
+    sh -c "go test -bench=${TEST_BENCH_REGEXP:-.} -benchtime=${TEST_BENCH_TIME:-1x} -benchmem -json -mod=vendor ${TEST_FLAGS:--v} ${TEST_PKG:-./test/...} | gotestmetrics parse --output $TEST_OUT_DIR/gotestoutput.json"
 )

--- a/testconfig.yml
+++ b/testconfig.yml
@@ -1,13 +1,12 @@
 defaults:
   count: 3
-  benchtime: 0.01s
+  benchtime: 1x
 
 runs:
   BenchmarkBuild:
     BenchmarkBuildSimple:
       description: Simple build
       count: 4
-      benchtime: 0.1s
       metrics:
         duration:
           description: Time (s)
@@ -15,7 +14,6 @@ runs:
     BenchmarkBuildMultistage:
       description: Multistage build
       count: 4
-      benchtime: 0.1s
       metrics:
         duration:
           description: Time (s)
@@ -23,7 +21,6 @@ runs:
     BenchmarkBuildSecret:
       description: Build with secret
       count: 4
-      benchtime: 1s
       metrics:
         duration:
           description: Time (s)
@@ -31,7 +28,6 @@ runs:
     BenchmarkBuildRemote:
       description: Build from git context
       count: 4
-      benchtime: 1s
       metrics:
         duration:
           description: Time (s)
@@ -39,7 +35,6 @@ runs:
     BenchmarkBuildBreaker16:
       description: Build breaker 16x
       count: 3
-      benchtime: 0.1s
       metrics:
         duration:
           description: Time (s)
@@ -47,7 +42,6 @@ runs:
     BenchmarkBuildBreaker32:
       description: Build breaker 32x
       count: 4
-      benchtime: 0.1s
       metrics:
         duration:
           description: Time (s)
@@ -55,7 +49,6 @@ runs:
     BenchmarkBuildBreaker64:
       description: Build breaker 64x
       count: 4
-      benchtime: 1s
       metrics:
         duration:
           description: Time (s)
@@ -63,7 +56,6 @@ runs:
     BenchmarkBuildBreaker128:
       description: Build breaker 128x
       count: 4
-      benchtime: 1s
       metrics:
         duration:
           description: Time (s)
@@ -71,7 +63,6 @@ runs:
     BenchmarkBuildFileTransfer:
       description: Build with substantial file transfer
       count: 4
-      benchtime: 1s
       metrics:
         duration:
           description: Time (s)
@@ -81,7 +72,6 @@ runs:
     BenchmarkDaemonVersion:
       description: Run buildkitd --version
       count: 8
-      benchtime: 0.01s
       metrics:
         duration:
           description: Time (s)
@@ -89,7 +79,6 @@ runs:
     BenchmarkDaemonSize:
       description: Daemon binary size
       count: 1
-      benchtime: 1s
       metrics:
         bytes:
           description: Size (bytes)
@@ -100,7 +89,6 @@ runs:
     BenchmarkPackageSize:
       description: Package size
       count: 1
-      benchtime: 1s
       metrics:
         bytes:
           description: Size (bytes)


### PR DESCRIPTION
In some cases we have really tiny benchmark and therefore we needed to adjust benchtime to avoid the benchmark to hang as there would not have been enough iteration. Instead of using a duration we can just default to the number of iteration we want, in this case `1x`:

```
        -benchtime t
            Run enough iterations of each benchmark to take t, specified
            as a time.Duration (for example, -benchtime 1h30s).
            The default is 1 second (1s).
            The special syntax Nx means to run the benchmark N times
            (for example, -benchtime 100x).
```

As follow-up we can look what benchmarks need iteration adjustment.