### PR TITLE
website: load result metadata at build time

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,29 +59,6 @@ website with:
 make gen
 ```
 
-```text
-...
-[+] Running 1/0
- ✔ Container website-serve-1  Created                                                                                                                                                                     0.0s 
-Attaching to serve-1
-serve-1  | Running generateResults.js...
-serve-1  | /src/public/results.json has been generated successfully.
-serve-1  |  INFO  Starting development server...
- DONE  Compiled successfully in 947ms2:39:29 PM
-serve-1  |
-                                                                                                                                                                                                               
-serve-1  |   App running at:
-serve-1  |   - Local:   http://localhost:8080/
-serve-1  |
-serve-1  |   It seems you are running Vue CLI inside a container.
-serve-1  |   Access the dev server via http://localhost:<your container's external mapped port>/
-serve-1  |
-serve-1  |   Note that the development build is not optimized.
-serve-1  |   To create a production build, run yarn build.
-serve-1  |
-Build finished at 14:39:29 by 0.000s
-```
-
 Then open [http://localhost:8080](http://localhost:8080) in your browser.
 
 ## License

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -14,4 +14,4 @@ jspm_packages/
 
 dist
 public/result
-public/results.json
+src/assets/results.json

--- a/website/generateResults.js
+++ b/website/generateResults.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 
 const resultsDir = path.join(__dirname, 'public', 'result');
-const outputFilePath = path.join(__dirname, 'public', 'results.json');
+const outputFilePath = path.join(__dirname, 'src', 'assets', 'results.json');
 
 console.log('Running generateResults.js...');
 

--- a/website/src/components/ResultsList.vue
+++ b/website/src/components/ResultsList.vue
@@ -18,13 +18,10 @@ export default {
       selectedResult: null
     };
   },
-  created() {
-    fetch('results.json')
-        .then(response => response.json())
-        .then(data => {
-          this.results = data.results.sort((a, b) => b.localeCompare(a));
-          this.updateSelectedResult();
-        });
+  async created() {
+    const resultsData = await import(`../assets/results.json`);
+    this.results = resultsData.results.sort((a, b) => b.localeCompare(a));
+    this.updateSelectedResult();
   },
   watch: {
     '$route.params.result': 'updateSelectedResult'

--- a/website/vue.config.js
+++ b/website/vue.config.js
@@ -8,5 +8,8 @@ module.exports = {
         '@': path.resolve(__dirname, 'src')
       }
     }
+  },
+  chainWebpack: config => {
+    config.module.rule('text').test(/\.txt$/).type('asset/source');
   }
 };


### PR DESCRIPTION
This is to avoid XHR requests when using `fetch` so metadata are solved at build time.