### PR TITLE
testutil: fix bench timing

### DIFF
--- a/util/testutil/run.go
+++ b/util/testutil/run.go
@@ -254,6 +254,7 @@ func Run(tb testing.TB, runners []Runner, opt ...TestOpt) {
 							}
 							if b, ok := tb.(*testing.B); ok {
 								b.ResetTimer()
+								b.StopTimer()
 								for i := 0; i < b.N; i++ {
 									runWithSandbox(b)
 								}


### PR DESCRIPTION
oversight from https://github.com/moby/buildkit-bench/pull/126