### PR TITLE
test: warmup before running high parallelization bench

### DIFF
--- a/test/build_test.go
+++ b/test/build_test.go
@@ -156,6 +156,18 @@ FROM busybox:latest AS base
 COPY foo /etc/foo
 RUN cp /etc/foo /etc/bar
 `)
+
+	// warmup
+	for i := 0; i < 5; i++ {
+		dir := tmpdir(
+			b,
+			fstest.CreateFile("Dockerfile", dockerfile, 0600),
+			fstest.CreateFile("foo", []byte("foo"), 0600),
+		)
+		out, err := buildxBuildCmd(sb, withArgs("--output=type=image", dir))
+		require.NoError(b, err, out)
+	}
+
 	var wg sync.WaitGroup
 	for i := 0; i < n; i++ {
 		wg.Add(1)


### PR DESCRIPTION
With image export added in https://github.com/moby/buildkit-bench/pull/146#discussion_r1771580503, we are now seeing gaps for timing between runs for high parallelization build benchs:

![image](https://github.com/user-attachments/assets/780cb4ac-b90a-436a-8a05-5fcf0beb012f)

```
$ TEST_KEEP_CACHE=1 TEST_BENCH_RUN=3 BUILDKIT_REFS=v0.9.3,v0.15.2,master TEST_BENCH_REGEXP=/BenchmarkBuildHighParallelization32x$ make bench
...
goos: linux
goarch: amd64
pkg: github.com/moby/buildkit-bench/test
cpu: AMD Ryzen 9 5950X 16-Core Processor
BenchmarkBuild
time="2024-09-26T10:28:14Z" level=info msg="starting registry mirror"
time="2024-09-26T10:28:14Z" level=info msg="registry mirror started at localhost:45415"
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=master/run=1
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=master/run=1-32                        1        33208780898 ns/op        180004146 alloc         1187904 B/op       3251 allocs/op
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=master/run=2
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=master/run=2-32                        1        35120443546 ns/op        185352209 alloc         1104416 B/op       3087 allocs/op
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=master/run=3
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=master/run=3-32                        1        31719429786 ns/op        173720028 alloc         1088816 B/op       3117 allocs/op
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=v0.15.2/run=1
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=v0.15.2/run=1-32                       1        45466969815 ns/op        180238668 alloc          829432 B/op       3094 allocs/op
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=v0.15.2/run=2
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=v0.15.2/run=2-32                       1        50235481226 ns/op        189181652 alloc          836344 B/op       3121 allocs/op
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=v0.15.2/run=3
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=v0.15.2/run=3-32                       1        50312278063 ns/op        166460288 alloc          819456 B/op       3060 allocs/op
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=v0.9.3/run=1
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=v0.9.3/run=1-32                        1        29434371366 ns/op        542565856 alloc          705688 B/op       3091 allocs/op
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=v0.9.3/run=2
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=v0.9.3/run=2-32                        1        44684897721 ns/op        568729128 alloc          727440 B/op       3082 allocs/op
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=v0.9.3/run=3
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=v0.9.3/run=3-32                        1        27355956503 ns/op        519130083 alloc          710360 B/op       3074 allocs/op
BenchmarkDaemon
BenchmarkPackage
PASS
ok      github.com/moby/buildkit-bench/test     349.460s
```

Warming up builds should avoid that:

```
$ TEST_KEEP_CACHE=1 TEST_BENCH_RUN=3 BUILDKIT_REFS=v0.9.3,v0.15.2,master TEST_BENCH_REGEXP=/BenchmarkBuildHighParallelization32x$ make bench
goos: linux
goarch: amd64
pkg: github.com/moby/buildkit-bench/test
cpu: AMD Ryzen 9 5950X 16-Core Processor
BenchmarkBuild
time="2024-09-26T10:24:40Z" level=info msg="starting registry mirror"
time="2024-09-26T10:24:40Z" level=info msg="registry mirror started at localhost:44423"
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=master/run=1
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=master/run=1-32                        1        15373181023 ns/op        192556006 alloc          962872 B/op       3034 allocs/op
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=master/run=2
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=master/run=2-32                        1        15954934623 ns/op        184445888 alloc          946256 B/op       3041 allocs/op
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=master/run=3
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=master/run=3-32                        1        15118800772 ns/op        184409766 alloc          947448 B/op       3029 allocs/op
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=v0.15.2/run=1
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=v0.15.2/run=1-32                       1        14408004368 ns/op        193248324 alloc          752440 B/op       3027 allocs/op
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=v0.15.2/run=2
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=v0.15.2/run=2-32                       1        14524380448 ns/op        198626239 alloc          745824 B/op       3012 allocs/op
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=v0.15.2/run=3
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=v0.15.2/run=3-32                       1        14308408629 ns/op        178511125 alloc          748384 B/op       3018 allocs/op
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=v0.9.3/run=1
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=v0.9.3/run=1-32                        1        11846323679 ns/op        463499721 alloc          598000 B/op       3016 allocs/op
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=v0.9.3/run=2
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=v0.9.3/run=2-32                        1        11561861896 ns/op        478502181 alloc          604024 B/op       2999 allocs/op
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=v0.9.3/run=3
BenchmarkBuild/BenchmarkBuildHighParallelization32x/ref=v0.9.3/run=3-32                        1        11629957601 ns/op        515007489 alloc          596568 B/op       3013 allocs/op
BenchmarkDaemon
BenchmarkPackage
PASS
ok      github.com/moby/buildkit-bench/test     157.374s
...
