### PR TITLE
candidates: always get latest rc

### DIFF
--- a/util/candidates/candidates.go
+++ b/util/candidates/candidates.go
@@ -206,7 +206,9 @@ func filterFeatureReleases(tags []*ggithub.RepositoryTag, last int) []*ggithub.R
 		}
 		if semver.IsValid(*tag.Name) {
 			if semver.Prerelease(*tag.Name) != "" && len(latestReleases) == 0 && len(zeroReleases) == 0 {
-				latestRC = tag
+				if latestRC == nil {
+					latestRC = tag
+				}
 				continue
 			}
 			mm := semver.MajorMinor(*tag.Name)


### PR DESCRIPTION
If there are multiple RCs the oldest one is always returned. We should always get the latest RC.