### PR TITLE
ci: free disk space when publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,6 +283,15 @@ jobs:
       - report
     steps:
       -
+        name: Free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
+      -
         name: Checkout
         uses: actions/checkout@v4
       -
@@ -310,6 +319,7 @@ jobs:
         name: Build website
         uses: docker/bake-action@v5
         with:
+          no-cache: true
           targets: website
           provenance: false
       -


### PR DESCRIPTION
We got no space left on github runners when trying to publish: https://github.com/moby/buildkit-bench/actions/runs/12007277408/job/33491722706

Probably because of the logs so let remove unneeded tools.