### PR TITLE
ci(gc): free disk space

### DIFF
--- a/.github/workflows/gc.yml
+++ b/.github/workflows/gc.yml
@@ -25,6 +25,15 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       -
+        name: Free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
+      -
         name: Checkout
         uses: actions/checkout@v4
       -


### PR DESCRIPTION
similar to https://github.com/moby/buildkit-bench/pull/187

relates to https://github.com/moby/buildkit-bench/actions/runs/12093057272:

![image](https://github.com/user-attachments/assets/f3f2ce21-00af-4a8b-a9c8-7b9200a3ccb3)
