### PR TITLE
gen: compress logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,9 @@ jobs:
       -
         name: Include results to report
         run: |
+          if [[ -f ./bin/report/logs.tar.gz ]] && [[ -d /tmp/bench-results/logs ]]; then
+            rm -rf /tmp/bench-results/logs
+          fi
           cp -r /tmp/bench-results/* ./bin/report/
       -
         name: Upload report

--- a/.github/workflows/regen.yml
+++ b/.github/workflows/regen.yml
@@ -107,6 +107,15 @@ jobs:
       - gen
     steps:
       -
+        name: Free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
+      -
         name: Checkout
         uses: actions/checkout@v4
       -

--- a/.github/workflows/regen.yml
+++ b/.github/workflows/regen.yml
@@ -89,6 +89,9 @@ jobs:
       -
         name: Copy files
         run: |
+          if [[ -f ./bin/report/${{ matrix.result }}/logs.tar.gz ]] && [[ -d ./bin/gh-pages/result/${{ matrix.result }}/logs ]]; then
+            rm -rf ./bin/gh-pages/result/${{ matrix.result }}/logs
+          fi
           rsync -av --exclude='*.html' ./bin/gh-pages/result/${{ matrix.result }}/ ./bin/report/${{ matrix.result }}/
       -
         name: Upload report

--- a/Dockerfile
+++ b/Dockerfile
@@ -125,6 +125,10 @@ ARG GITHUB_ACTIONS
 ARG GEN_VALIDATION_MODE
 RUN --mount=type=bind,target=. <<EOT
   set -e
+  mkdir -p /out
+  if [ -d /tests-results/logs ]; then
+    tar -czvf /out/logs.tar.gz -C /tests-results/logs .
+  fi
   gotestmetrics-gen buildkit
   gotestmetrics-gen buildx
 EOT

--- a/website/src/components/ResultView.vue
+++ b/website/src/components/ResultView.vue
@@ -98,7 +98,7 @@ export default {
         }
         this.metadataLinks.push({
           text: `Logs`,
-          url: `https://github.com/${repo}/tree/gh-pages/result/${resultName}/logs`,
+          url: `https://github.com/${repo}/raw/refs/heads/gh-pages/result/${resultName}/logs.tar.gz`,
           icon: require('../assets/logs.svg')
         });
       } catch (error) {


### PR DESCRIPTION
Publish job hangs due to large amount of logs for each result when pushing to github pages.