### PR TITLE
switch to actions/deploy-pages to deploy website

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,9 +283,6 @@ jobs:
 
   publish:
     runs-on: ubuntu-24.04
-    permissions:
-      # required to push to gh-pages
-      contents: write
     needs:
       - report
     steps:
@@ -302,11 +299,36 @@ jobs:
         name: Checkout
         uses: actions/checkout@v6
       -
-        name: Checkout gh-pages
+        name: Download deployed results
+        id: pages-results
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { exitCode } = await exec.getExecOutput('node', ['./website/downloadResults.js'], {
+              ignoreReturnCode: true,
+            });
+            if (exitCode === 0) {
+              core.setOutput('downloaded', 'true');
+            } else if (exitCode === 2) {
+              core.setOutput('downloaded', 'false');
+            } else {
+              core.setFailed(`downloadResults.js failed with exit code ${exitCode}`);
+            }
+      -
+        name: Checkout gh-pages fallback
+        if: steps.pages-results.outputs.downloaded != 'true'
         uses: actions/checkout@v6
         with:
           ref: gh-pages
           path: bin/gh-pages
+      -
+        name: Copy gh-pages fallback results
+        if: steps.pages-results.outputs.downloaded != 'true'
+        run: |
+          if [ -d ./bin/gh-pages/result ]; then
+            mkdir -p ./website/public/result
+            cp -a ./bin/gh-pages/result/. ./website/public/result/
+          fi
       -
         name: Download report
         uses: actions/download-artifact@v8
@@ -317,11 +339,13 @@ jobs:
         name: Move reports
         run: |
           reportDir=$(cat /tmp/bench-report/name.txt)
+          rm -rf ./website/public/result/$reportDir
           mkdir -p ./website/public/result/$reportDir
           mv /tmp/bench-report/* ./website/public/result/$reportDir/
-          if [ -d ./bin/gh-pages/result ]; then
-            mv ./bin/gh-pages/result/* ./website/public/result/
-          fi
+      -
+        name: Garbage collect old results
+        run: |
+          node ./website/pruneResults.js
       -
         name: Build website
         uses: docker/bake-action@v7
@@ -331,12 +355,24 @@ jobs:
           targets: website
           provenance: false
       -
-        name: Publish
-        uses: crazy-max/ghaction-github-pages@v5
+        name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v5
         with:
-          target_branch: gh-pages
-          build_dir: ./bin/website
-          jekyll: false
-          dry_run: ${{ github.event_name == 'pull_request' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          path: ./bin/website
+
+  deploy:
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-24.04
+    permissions:
+      pages: write
+      id-token: write
+    needs:
+      - publish
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      -
+        name: Deploy GitHub Pages site
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/gc.yml
+++ b/.github/workflows/gc.yml
@@ -17,9 +17,15 @@ on:
       - master
     paths:
       - .github/workflows/gc.yml
+      - website/downloadResults.js
+      - website/generateResults.js
+      - website/pruneResults.js
   pull_request:
     paths:
       - .github/workflows/gc.yml
+      - website/downloadResults.js
+      - website/generateResults.js
+      - website/pruneResults.js
 
 env:
   WEBSITE_PUBLIC_PATH: /buildkit-bench/
@@ -28,8 +34,7 @@ jobs:
   gc:
     runs-on: ubuntu-24.04
     permissions:
-      # required to push to gh-pages
-      contents: write
+      contents: read
     steps:
       -
         name: Free disk space
@@ -44,104 +49,71 @@ jobs:
         name: Checkout
         uses: actions/checkout@v6
       -
-        name: Checkout gh-pages
+        name: Download deployed results
+        id: pages-results
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { exitCode } = await exec.getExecOutput('node', ['./website/downloadResults.js'], {
+              ignoreReturnCode: true,
+            });
+            if (exitCode === 0) {
+              core.setOutput('downloaded', 'true');
+            } else if (exitCode === 2) {
+              core.setOutput('downloaded', 'false');
+            } else {
+              core.setFailed(`downloadResults.js failed with exit code ${exitCode}`);
+            }
+      -
+        name: Checkout gh-pages fallback
+        if: steps.pages-results.outputs.downloaded != 'true'
         uses: actions/checkout@v6
         with:
           ref: gh-pages
           path: bin/gh-pages
       -
-        name: Garbage collect old results
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const fs = require('fs');
-            const path = require('path');
-            const keepResultsPerDay = 1;
-            const monthsToKeep = 6;
-            
-            function parseDate(dateStr) {
-              const year = parseInt(dateStr.substring(0, 4), 10);
-              const month = parseInt(dateStr.substring(4, 6), 10) - 1;
-              const day = parseInt(dateStr.substring(6, 8), 10);
-              return new Date(year, month, day);
-            }
-
-            const resultDir = './bin/gh-pages/result';
-            const results = fs.readdirSync(resultDir).filter(d => {
-              return fs.statSync(path.join(resultDir, d)).isDirectory();
-            });
-
-            const resultsByDate = results.reduce((acc, dir) => {
-              const date = dir.split('-')[0];
-              if (!acc[date]) {
-                acc[date] = [];
-              }
-              acc[date].push(dir);
-              return acc;
-            }, {});
-            
-            const cutoff = new Date();
-            cutoff.setMonth(cutoff.getMonth() - monthsToKeep);
-            cutoff.setHours(0, 0, 0, 0);
-
-            Object.keys(resultsByDate).forEach(date => {
-              const dirs = resultsByDate[date];
-              const removeDirs = [];
-              
-              const pdate = parseDate(date);
-              if (Number.isNaN(pdate.getTime())) {
-                core.warning(`Skipping unrecognized date format in ${date}`);
-                return;
-              }
-
-              if (pdate < cutoff) {
-                dirs.forEach(dir => {
-                  const dirPath = path.join(resultDir, dir);
-                  fs.rmSync(dirPath, { recursive: true, force: true });
-                  core.info(`Removed ${dirPath} (older than ${monthsToKeep} months)`);
-                });
-                return;
-              }
-              
-              dirs.forEach(dir => {
-                const envFilePath = path.join(resultDir, dir, 'env.txt');
-                if (fs.existsSync(envFilePath)) {
-                  const envContent = fs.readFileSync(envFilePath, 'utf8');
-                  if (envContent.includes('GITHUB_EVENT_NAME=schedule')) {
-                    // always keep scheduled results
-                    return;
-                  }
-                }
-                removeDirs.push(dir);
-              });
-              if (removeDirs.length === 0) {
-                return;
-              }
-              removeDirs.sort().reverse();
-              removeDirs.slice(keepResultsPerDay).forEach(dir => {
-                const dirPath = path.join(resultDir, dir);
-                fs.rmSync(dirPath, { recursive: true, force: true });
-                core.info(`Removed ${dirPath}`);
-              });
-            });
-      -
-        name: Move and list results
+        name: Copy gh-pages fallback results
+        if: steps.pages-results.outputs.downloaded != 'true'
         run: |
-          mv ./bin/gh-pages/result ./website/public/
+          if [ -d ./bin/gh-pages/result ]; then
+            mkdir -p ./website/public/result
+            cp -a ./bin/gh-pages/result/. ./website/public/result/
+          fi
+      -
+        name: Garbage collect old results
+        run: |
+          node ./website/pruneResults.js
+      -
+        name: List results
+        run: |
           tree -nph ./website/public/result
       -
         name: Build website
         uses: docker/bake-action@v7
         with:
+          source: .
+          no-cache: true
           targets: website
           provenance: false
       -
-        name: Publish
-        uses: crazy-max/ghaction-github-pages@v5
+        name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v5
         with:
-          target_branch: gh-pages
-          build_dir: ./bin/website
-          jekyll: false
-          dry_run: ${{ github.event_name == 'pull_request' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          path: ./bin/website
+
+  deploy:
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-24.04
+    permissions:
+      pages: write
+      id-token: write
+    needs:
+      - gc
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      -
+        name: Deploy GitHub Pages site
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/regen.yml
+++ b/.github/workflows/regen.yml
@@ -35,24 +35,62 @@ jobs:
       results: ${{ steps.set.outputs.results }}
     steps:
       -
-        name: Checkout gh-pages
+        name: Checkout
+        uses: actions/checkout@v6
+      -
+        name: List deployed results
+        id: pages-results
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { exitCode, stdout } = await exec.getExecOutput('node', ['./website/downloadResults.js', '--list'], {
+              ignoreReturnCode: true,
+            });
+            if (exitCode === 0) {
+              core.setOutput('listed', 'true');
+              core.setOutput('results', stdout.trim());
+            } else if (exitCode === 2) {
+              core.setOutput('listed', 'false');
+            } else {
+              core.setFailed(`downloadResults.js failed with exit code ${exitCode}`);
+            }
+      -
+        name: Checkout gh-pages fallback
+        if: steps.pages-results.outputs.listed != 'true'
         uses: actions/checkout@v6
         with:
           ref: gh-pages
+          path: bin/gh-pages
+      -
+        name: Copy gh-pages fallback results
+        if: steps.pages-results.outputs.listed != 'true'
+        run: |
+          if [ -d ./bin/gh-pages/result ]; then
+            mkdir -p ./website/public/result
+            cp -a ./bin/gh-pages/result/. ./website/public/result/
+          fi
       -
         name: Create results matrix
         uses: actions/github-script@v9
         id: set
         with:
           script: |
+            const deployedResults = process.env.DEPLOYED_RESULTS;
+            if (deployedResults) {
+              core.info(deployedResults);
+              core.setOutput('results', deployedResults);
+              return;
+            }
             const fs = require('fs');
             const path = require('path');
-            const resultDir = './result';
+            const resultDir = './website/public/result';
             const results = JSON.stringify(fs.readdirSync(resultDir).filter(d => {
               return fs.statSync(path.join(resultDir, d)).isDirectory();
             }), null, 2);
             core.info(results);
             core.setOutput('results', results);
+        env:
+          DEPLOYED_RESULTS: ${{ steps.pages-results.outputs.results }}
 
   gen:
     runs-on: ubuntu-24.04
@@ -67,11 +105,36 @@ jobs:
         name: Checkout
         uses: actions/checkout@v6
       -
-        name: Checkout gh-pages
+        name: Download deployed result
+        id: pages-result
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { exitCode } = await exec.getExecOutput('node', ['./website/downloadResults.js', process.env.RESULT_NAME], {
+              ignoreReturnCode: true,
+            });
+            if (exitCode === 0) {
+              core.setOutput('downloaded', 'true');
+            } else if (exitCode === 2) {
+              core.setOutput('downloaded', 'false');
+            } else {
+              core.setFailed(`downloadResults.js failed with exit code ${exitCode}`);
+            }
+        env:
+          RESULT_NAME: ${{ matrix.result }}
+      -
+        name: Checkout gh-pages fallback
+        if: steps.pages-result.outputs.downloaded != 'true'
         uses: actions/checkout@v6
         with:
           ref: gh-pages
           path: bin/gh-pages
+      -
+        name: Copy gh-pages fallback result
+        if: steps.pages-result.outputs.downloaded != 'true'
+        run: |
+          mkdir -p ./website/public/result/${{ matrix.result }}
+          cp -a ./bin/gh-pages/result/${{ matrix.result }}/. ./website/public/result/${{ matrix.result }}/
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -88,15 +151,15 @@ jobs:
           provenance: false
           set: |
             *.cache-from=type=registry,ref=${{ env.BUILDKIT_CACHE_REPO }}:tests-base
-            *.contexts.tests-results=cwd://bin/gh-pages/result/${{ matrix.result }}
+            *.contexts.tests-results=cwd://website/public/result/${{ matrix.result }}
             *.output=./bin/report/${{ matrix.result }}
       -
         name: Copy files
         run: |
-          if [[ -f ./bin/report/${{ matrix.result }}/logs.tar.gz ]] && [[ -d ./bin/gh-pages/result/${{ matrix.result }}/logs ]]; then
-            rm -rf ./bin/gh-pages/result/${{ matrix.result }}/logs
+          if [[ -f ./bin/report/${{ matrix.result }}/logs.tar.gz ]] && [[ -d ./website/public/result/${{ matrix.result }}/logs ]]; then
+            rm -rf ./website/public/result/${{ matrix.result }}/logs
           fi
-          rsync -av --exclude='*.html' ./bin/gh-pages/result/${{ matrix.result }}/ ./bin/report/${{ matrix.result }}/
+          rsync -av --exclude='*.html' ./website/public/result/${{ matrix.result }}/ ./bin/report/${{ matrix.result }}/
       -
         name: Upload report
         uses: actions/upload-artifact@v7
@@ -108,8 +171,7 @@ jobs:
   publish:
     runs-on: ubuntu-24.04
     permissions:
-      # required to push to gh-pages
-      contents: write
+      contents: read
     needs:
       - gen
     steps:
@@ -136,15 +198,29 @@ jobs:
         name: Build website
         uses: docker/bake-action@v7
         with:
+          source: .
+          no-cache: true
           targets: website
           provenance: false
       -
-        name: Publish
-        uses: crazy-max/ghaction-github-pages@v5
+        name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v5
         with:
-          target_branch: gh-pages
-          build_dir: ./bin/website
-          jekyll: false
-          dry_run: ${{ github.event_name == 'pull_request' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          path: ./bin/website
+
+  deploy:
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-24.04
+    permissions:
+      pages: write
+      id-token: write
+    needs:
+      - publish
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      -
+        name: Deploy GitHub Pages site
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/website/downloadResults.js
+++ b/website/downloadResults.js
@@ -1,0 +1,133 @@
+const fs = require('fs');
+const path = require('path');
+
+const repository = process.env.GITHUB_REPOSITORY || 'moby/buildkit-bench';
+const [repositoryOwner, repositoryName] = repository.split('/');
+const defaultPagesUrl = `https://${repositoryOwner}.github.io/${repositoryName}/`;
+const pagesUrl = ensureTrailingSlash(process.env.PAGES_URL || defaultPagesUrl);
+const resultsDir = process.env.RESULTS_DIR || path.join(__dirname, 'public', 'result');
+const args = process.argv.slice(2);
+const listOnly = args.includes('--list');
+const requestedResults = new Set(args.filter(arg => arg && arg !== '--list'));
+
+function ensureTrailingSlash(value) {
+  return value.endsWith('/') ? value : `${value}/`;
+}
+
+function validatePathSegment(value, field) {
+  if (!value || value.includes('/') || value.includes('\\') || value === '.' || value === '..') {
+    throw new Error(`Invalid ${field}: ${value}`);
+  }
+  return value;
+}
+
+function validateRelativePath(value) {
+  const normalized = value.replace(/\\/g, '/');
+  const segments = normalized.split('/');
+
+  if (normalized.startsWith('/') || segments.some(segment => {
+    return !segment || segment === '.' || segment === '..';
+  })) {
+    throw new Error(`Invalid manifest file path: ${value}`);
+  }
+
+  return segments;
+}
+
+function resultUrl(resultName, filePath) {
+  const encodedPath = ['result', resultName, ...validateRelativePath(filePath)]
+    .map(segment => encodeURIComponent(segment))
+    .join('/');
+  return new URL(encodedPath, pagesUrl).toString();
+}
+
+async function fetchRequired(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to download ${url}: ${response.status} ${response.statusText}`);
+  }
+  return response;
+}
+
+async function downloadFile(resultName, filePath) {
+  const response = await fetchRequired(resultUrl(resultName, filePath));
+  const destination = path.join(resultsDir, resultName, ...validateRelativePath(filePath));
+
+  await fs.promises.mkdir(path.dirname(destination), { recursive: true });
+  await fs.promises.writeFile(destination, Buffer.from(await response.arrayBuffer()));
+}
+
+function normalizeManifest(manifest) {
+  if (!manifest || !Array.isArray(manifest.results)) {
+    throw new Error('Pages result manifest does not contain a results array');
+  }
+
+  return manifest.results.map(result => {
+    if (!result || typeof result !== 'object') {
+      throw new Error('Pages result manifest contains an invalid result entry');
+    }
+    if (!Array.isArray(result.files)) {
+      throw new Error(`Pages result manifest entry for ${result.name} does not contain files`);
+    }
+
+    return {
+      name: validatePathSegment(result.name, 'result name'),
+      files: result.files.map(file => validateRelativePath(file).join('/')),
+    };
+  });
+}
+
+async function readManifest() {
+  const manifestUrl = new URL('result/manifest.json', pagesUrl).toString();
+  const response = await fetch(manifestUrl);
+
+  if (response.status === 404) {
+    console.warn(`No Pages result manifest found at ${manifestUrl}`);
+    process.exitCode = 2;
+    return null;
+  }
+  if (!response.ok) {
+    throw new Error(`Failed to download ${manifestUrl}: ${response.status} ${response.statusText}`);
+  }
+
+  return normalizeManifest(await response.json());
+}
+
+async function main() {
+  const manifest = await readManifest();
+  if (!manifest) {
+    return;
+  }
+  if (listOnly) {
+    console.log(JSON.stringify(manifest.map(result => result.name), null, 2));
+    return;
+  }
+
+  const selectedResults = requestedResults.size === 0
+    ? manifest
+    : manifest.filter(result => requestedResults.has(result.name));
+
+  const missingResults = [...requestedResults].filter(name => {
+    return !selectedResults.some(result => result.name === name);
+  });
+  if (missingResults.length > 0) {
+    throw new Error(`Pages result manifest does not contain: ${missingResults.join(', ')}`);
+  }
+
+  await fs.promises.mkdir(resultsDir, { recursive: true });
+
+  let fileCount = 0;
+  for (const result of selectedResults) {
+    for (const file of result.files) {
+      await downloadFile(result.name, file);
+      fileCount++;
+    }
+  }
+
+  console.log(`Downloaded ${fileCount} file(s) for ${selectedResults.length} result(s) from ${pagesUrl}`);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/website/generateResults.js
+++ b/website/generateResults.js
@@ -3,20 +3,55 @@ const path = require('path');
 
 const resultsDir = path.join(__dirname, 'public', 'result');
 const outputFilePath = path.join(__dirname, 'src', 'assets', 'results.json');
+const manifestFilePath = path.join(resultsDir, 'manifest.json');
 
 console.log('Running generateResults.js...');
 
-fs.readdir(resultsDir, { withFileTypes: true }, (err, files) => {
-  if (err) {
-    console.error(`Failed to read directory ${resultsDir}:`, err);
-    process.exit(1);
-  }
-  const results = { results: files.filter(file => file.isDirectory()).map(file => file.name) };
-  fs.writeFile(outputFilePath, JSON.stringify(results, null, 2), (err) => {
-    if (err) {
-      console.error(`Failed to write ${outputFilePath}:`, err);
-      process.exit(1);
+function toPosixPath(filePath) {
+  return filePath.split(path.sep).join('/');
+}
+
+async function listFiles(dir, prefix = '') {
+  const entries = await fs.promises.readdir(dir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name);
+    const relativePath = prefix ? path.join(prefix, entry.name) : entry.name;
+
+    if (entry.isDirectory()) {
+      files.push(...await listFiles(entryPath, relativePath));
+    } else if (entry.isFile()) {
+      files.push(toPosixPath(relativePath));
     }
-    console.log(`${outputFilePath} has been generated successfully.`);
-  });
+  }
+
+  return files.sort();
+}
+
+async function main() {
+  const files = await fs.promises.readdir(resultsDir, { withFileTypes: true });
+  const resultEntries = await Promise.all(files
+    .filter(file => file.isDirectory())
+    .map(async file => {
+      return {
+        name: file.name,
+        files: await listFiles(path.join(resultsDir, file.name)),
+      };
+    }));
+  resultEntries.sort((a, b) => a.name.localeCompare(b.name));
+
+  const results = { results: resultEntries.map(result => result.name) };
+  const manifest = { version: 1, results: resultEntries };
+
+  await fs.promises.writeFile(outputFilePath, JSON.stringify(results, null, 2));
+  console.log(`${outputFilePath} has been generated successfully.`);
+
+  await fs.promises.writeFile(manifestFilePath, JSON.stringify(manifest, null, 2));
+  console.log(`${manifestFilePath} has been generated successfully.`);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
 });

--- a/website/pruneResults.js
+++ b/website/pruneResults.js
@@ -1,0 +1,67 @@
+const fs = require('fs');
+const path = require('path');
+
+const resultsDir = process.env.RESULTS_DIR || path.join(__dirname, 'public', 'result');
+const keepResultsPerDay = Number.parseInt(process.env.KEEP_RESULTS_PER_DAY || '1', 10);
+const monthsToKeep = Number.parseInt(process.env.MONTHS_TO_KEEP || '3', 10);
+
+function parseDate(dateStr) {
+  const year = Number.parseInt(dateStr.substring(0, 4), 10);
+  const month = Number.parseInt(dateStr.substring(4, 6), 10) - 1;
+  const day = Number.parseInt(dateStr.substring(6, 8), 10);
+  return new Date(year, month, day);
+}
+
+function isScheduledResult(dir) {
+  const envFilePath = path.join(resultsDir, dir, 'env.txt');
+  if (!fs.existsSync(envFilePath)) {
+    return false;
+  }
+  return fs.readFileSync(envFilePath, 'utf8').includes('GITHUB_EVENT_NAME=schedule');
+}
+
+function removeResult(dir, reason) {
+  const dirPath = path.join(resultsDir, dir);
+  fs.rmSync(dirPath, { recursive: true, force: true });
+  console.log(`Removed ${dirPath}${reason ? ` (${reason})` : ''}`);
+}
+
+async function main() {
+  const entries = await fs.promises.readdir(resultsDir, { withFileTypes: true });
+  const resultsByDate = entries
+    .filter(entry => entry.isDirectory())
+    .map(entry => entry.name)
+    .reduce((acc, dir) => {
+      const date = dir.split('-')[0];
+      acc[date] = acc[date] || [];
+      acc[date].push(dir);
+      return acc;
+    }, {});
+
+  const cutoff = new Date();
+  cutoff.setMonth(cutoff.getMonth() - monthsToKeep);
+  cutoff.setHours(0, 0, 0, 0);
+
+  Object.keys(resultsByDate).forEach(date => {
+    const dirs = resultsByDate[date];
+    const pdate = parseDate(date);
+    if (Number.isNaN(pdate.getTime())) {
+      console.warn(`Skipping unrecognized date format in ${date}`);
+      return;
+    }
+
+    if (pdate < cutoff) {
+      dirs.forEach(dir => removeResult(dir, `older than ${monthsToKeep} months`));
+      return;
+    }
+
+    const removeDirs = dirs.filter(dir => !isScheduledResult(dir));
+    removeDirs.sort().reverse();
+    removeDirs.slice(keepResultsPerDay).forEach(dir => removeResult(dir));
+  });
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/website/src/components/ResultView.vue
+++ b/website/src/components/ResultView.vue
@@ -98,7 +98,7 @@ export default {
         }
         this.metadataLinks.push({
           text: `Logs`,
-          url: `https://github.com/${repo}/raw/refs/heads/gh-pages/result/${resultName}/logs.tar.gz`,
+          url: `${process.env.BASE_URL}result/${resultName}/logs.tar.gz`,
           icon: require('../assets/logs.svg')
         });
       } catch (error) {


### PR DESCRIPTION
fixes https://github.com/moby/buildkit-bench/issues/93

This changes the website deployment flow to use the official GitHub Pages artifact deployment actions instead of publishing generated files to the `gh-pages` branch.

This moves Pages publishing onto the supported GitHub Actions deployment path and avoids continuing to grow a branch with generated site output. A one-time fallback still reads the existing `gh-pages` branch when no deployed manifest exists, so the first migrated deployment can seed the new artifact-based history before the branch is deleted.