### PR TITLE
move ADD tar payloads into archiveutil

### DIFF
--- a/test/build_test.go
+++ b/test/build_test.go
@@ -1,11 +1,7 @@
 package test
 
 import (
-	"archive/tar"
 	"fmt"
-	"io"
-	"math/rand"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -13,6 +9,7 @@ import (
 
 	"github.com/containerd/continuity/fs/fstest"
 	"github.com/containerd/platforms"
+	"github.com/moby/buildkit-bench/util/archiveutil"
 	"github.com/moby/buildkit-bench/util/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -20,16 +17,6 @@ import (
 const dockerfileImagePin = "docker/dockerfile:1.9.0"
 
 var contextDirApplier fstest.Applier
-
-const (
-	addTarManyFileDirs          = 100
-	addTarManyFilesPerDir       = 100
-	addTarManyFileMinSizeBytes  = 10 * 1024
-	addTarManyFileMaxSizeBytes  = 2 * 1024 * 1024
-	addTarManyFileMaxTotalBytes = 512 * 1024 * 1024
-	addTarManyFileRandSeed      = 1
-	addTarLargeFileSizeBytes    = 512 * 1024 * 1024
-)
 
 func BenchmarkBuild(b *testing.B) {
 	mirroredImages := testutil.OfficialImages(
@@ -260,13 +247,13 @@ RUN du -sh . && tree .
 }
 
 func benchmarkBuildAddTarManyFiles(b *testing.B, sb testutil.Sandbox) {
-	dockerfile := []byte(`
+	dockerfile := []byte(fmt.Sprintf(`
 FROM busybox:latest
 ADD payload.tar /src/
-RUN test -f /src/payload/dir-099/file-099.txt
-`)
+RUN test -f /src/%s
+`, archiveutil.ManyFilesLastFileName()))
 	dir := tmpdir(b, fstest.CreateFile("Dockerfile", dockerfile, 0600))
-	writeManyFilesTar(b, filepath.Join(dir, "payload.tar"))
+	require.NoError(b, archiveutil.WriteManyFilesTar(filepath.Join(dir, "payload.tar")))
 
 	reportBuildkitdAlloc(b, sb, func() {
 		b.StartTimer()
@@ -282,9 +269,9 @@ func benchmarkBuildAddTarLargeFile(b *testing.B, sb testutil.Sandbox) {
 FROM busybox:latest
 ADD payload.tar /src/
 RUN test "$(stat -c %%s /src/payload/blob.bin)" = "%d"
-`, addTarLargeFileSizeBytes))
+`, archiveutil.LargeFileSizeBytes))
 	dir := tmpdir(b, fstest.CreateFile("Dockerfile", dockerfile, 0600))
-	writeLargeFileTar(b, filepath.Join(dir, "payload.tar"), addTarLargeFileSizeBytes)
+	require.NoError(b, archiveutil.WriteLargeFileTar(filepath.Join(dir, "payload.tar"), archiveutil.LargeFileSizeBytes))
 
 	reportBuildkitdAlloc(b, sb, func() {
 		b.StartTimer()
@@ -293,117 +280,6 @@ RUN test "$(stat -c %%s /src/payload/blob.bin)" = "%d"
 		sb.WriteLogFile(b, "buildx", []byte(out))
 		require.NoError(b, err, out)
 	})
-}
-
-func writeManyFilesTar(tb testing.TB, name string) {
-	tb.Helper()
-
-	f, err := os.Create(name)
-	require.NoError(tb, err)
-
-	tw := tar.NewWriter(f)
-
-	writeTarDir(tb, tw, "payload")
-	sizes := addTarManyFileSizes(tb)
-	fileNum := 0
-	for dirIndex := 0; dirIndex < addTarManyFileDirs; dirIndex++ {
-		dirName := fmt.Sprintf("payload/dir-%03d", dirIndex)
-		writeTarDir(tb, tw, dirName)
-		for fileIndex := 0; fileIndex < addTarManyFilesPerDir; fileIndex++ {
-			fileName := fmt.Sprintf("%s/file-%03d.txt", dirName, fileIndex)
-			writeTarFile(tb, tw, fileName, sizes[fileNum], zeroReader{})
-			fileNum++
-		}
-	}
-	require.NoError(tb, tw.Close())
-	require.NoError(tb, f.Close())
-}
-
-func addTarManyFileSizes(tb testing.TB) []int64 {
-	tb.Helper()
-
-	totalFiles := addTarManyFileDirs * addTarManyFilesPerDir
-	require.LessOrEqual(tb, int64(totalFiles*addTarManyFileMinSizeBytes), int64(addTarManyFileMaxTotalBytes))
-
-	rng := rand.New(rand.NewSource(addTarManyFileRandSeed))
-	sizes := make([]int64, 0, totalFiles)
-	remainingBudget := int64(addTarManyFileMaxTotalBytes)
-	for fileNum := 0; fileNum < totalFiles; fileNum++ {
-		remainingFiles := totalFiles - fileNum
-		maxSize := remainingBudget - int64(remainingFiles-1)*addTarManyFileMinSizeBytes
-		require.GreaterOrEqual(tb, maxSize, int64(addTarManyFileMinSizeBytes))
-		maxSize = min(maxSize, int64(addTarManyFileMaxSizeBytes))
-
-		size := randomAddTarManyFileSize(rng)
-		size = min(size, maxSize)
-		sizes = append(sizes, size)
-		remainingBudget -= size
-	}
-	return sizes
-}
-
-func randomAddTarManyFileSize(rng *rand.Rand) int64 {
-	switch rng.Intn(100) {
-	case 0:
-		return randInt64Range(rng, 512*1024, addTarManyFileMaxSizeBytes)
-	case 1, 2, 3, 4, 5, 6, 7, 8:
-		return randInt64Range(rng, 64*1024, 512*1024)
-	default:
-		return randInt64Range(rng, addTarManyFileMinSizeBytes, 32*1024)
-	}
-}
-
-func randInt64Range(rng *rand.Rand, minValue, maxValue int64) int64 {
-	if maxValue <= minValue {
-		return minValue
-	}
-	return minValue + rng.Int63n(maxValue-minValue+1)
-}
-
-func writeLargeFileTar(tb testing.TB, name string, size int64) {
-	tb.Helper()
-
-	f, err := os.Create(name)
-	require.NoError(tb, err)
-
-	tw := tar.NewWriter(f)
-
-	writeTarDir(tb, tw, "payload")
-	writeTarFile(tb, tw, "payload/blob.bin", size, zeroReader{})
-	require.NoError(tb, tw.Close())
-	require.NoError(tb, f.Close())
-}
-
-func writeTarDir(tb testing.TB, tw *tar.Writer, name string) {
-	tb.Helper()
-
-	err := tw.WriteHeader(&tar.Header{
-		Name:     name,
-		Typeflag: tar.TypeDir,
-		Mode:     0755,
-	})
-	require.NoError(tb, err)
-}
-
-func writeTarFile(tb testing.TB, tw *tar.Writer, name string, size int64, r io.Reader) {
-	tb.Helper()
-
-	err := tw.WriteHeader(&tar.Header{
-		Name: name,
-		Mode: 0644,
-		Size: size,
-	})
-	require.NoError(tb, err)
-
-	_, err = io.CopyN(tw, r, size)
-	require.NoError(tb, err)
-}
-
-type zeroReader struct{}
-
-func (zeroReader) Read(p []byte) (int, error) {
-	clear(p)
-	return len(p), nil
 }
 
 // https://github.com/moby/buildkit/pull/4949

--- a/util/archiveutil/tar.go
+++ b/util/archiveutil/tar.go
@@ -1,0 +1,183 @@
+package archiveutil
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"os"
+)
+
+const (
+	manyFileDirs          = 100
+	manyFilesPerDir       = 100
+	manyFileMinSizeBytes  = 10 * 1024
+	manyFileMaxSizeBytes  = 2 * 1024 * 1024
+	manyFileMaxTotalBytes = 512 * 1024 * 1024
+	LargeFileSizeBytes    = 512 * 1024 * 1024
+)
+
+func WriteManyFilesTar(name string) error {
+	f, err := os.Create(name)
+	if err != nil {
+		return err
+	}
+
+	tw := tar.NewWriter(f)
+	if err := writeManyFilesTar(tw); err != nil {
+		_ = tw.Close()
+		_ = f.Close()
+		return err
+	}
+	if err := tw.Close(); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
+}
+
+func WriteLargeFileTar(name string, size int64) error {
+	f, err := os.Create(name)
+	if err != nil {
+		return err
+	}
+
+	tw := tar.NewWriter(f)
+	if err := writeTarDir(tw, "payload"); err != nil {
+		_ = tw.Close()
+		_ = f.Close()
+		return err
+	}
+	if err := writeTarFile(tw, "payload/blob.bin", size, zeroReader{}); err != nil {
+		_ = tw.Close()
+		_ = f.Close()
+		return err
+	}
+	if err := tw.Close(); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
+}
+
+func ManyFilesLastFileName() string {
+	return manyFileName(manyFileDirs-1, manyFilesPerDir-1)
+}
+
+func writeManyFilesTar(tw *tar.Writer) error {
+	if err := writeTarDir(tw, "payload"); err != nil {
+		return err
+	}
+	sizes, err := manyFileSizes()
+	if err != nil {
+		return err
+	}
+	fileNum := 0
+	for dirIndex := 0; dirIndex < manyFileDirs; dirIndex++ {
+		dirName := fmt.Sprintf("payload/dir-%03d", dirIndex)
+		if err := writeTarDir(tw, dirName); err != nil {
+			return err
+		}
+		for fileIndex := 0; fileIndex < manyFilesPerDir; fileIndex++ {
+			fileName := manyFileName(dirIndex, fileIndex)
+			if err := writeTarFile(tw, fileName, sizes[fileNum], zeroReader{}); err != nil {
+				return err
+			}
+			fileNum++
+		}
+	}
+	return nil
+}
+
+func manyFileSizes() ([]int64, error) {
+	totalFiles := manyFileDirs * manyFilesPerDir
+	if int64(totalFiles*manyFileMinSizeBytes) > int64(manyFileMaxTotalBytes) {
+		return nil, fmt.Errorf("minimum file sizes exceed total budget")
+	}
+
+	sizes := make([]int64, 0, totalFiles)
+	remainingBudget := int64(manyFileMaxTotalBytes)
+	for fileNum := 0; fileNum < totalFiles; fileNum++ {
+		remainingFiles := totalFiles - fileNum
+		maxSize := remainingBudget - int64(remainingFiles-1)*manyFileMinSizeBytes
+		if maxSize < int64(manyFileMinSizeBytes) {
+			return nil, fmt.Errorf("remaining budget below minimum file size")
+		}
+		maxSize = min(maxSize, int64(manyFileMaxSizeBytes))
+
+		size := manyFileSize(fileNum)
+		size = min(size, maxSize)
+		sizes = append(sizes, size)
+		remainingBudget -= size
+	}
+	if sumInt64(sizes) > int64(manyFileMaxTotalBytes) {
+		return nil, fmt.Errorf("file sizes exceed total budget")
+	}
+	return sizes, nil
+}
+
+func manyFileName(dirIndex, fileIndex int) string {
+	return fmt.Sprintf("payload/dir-%03d/file-%03d.txt", dirIndex, fileIndex)
+}
+
+func manyFileSize(fileNum int) int64 {
+	hash := manyFileHash(uint64(fileNum))
+	switch bucket := hash % 100; {
+	case bucket == 0:
+		return int64Range(hash>>8, 512*1024, manyFileMaxSizeBytes)
+	case bucket < 9:
+		return int64Range(hash>>8, 64*1024, 512*1024)
+	default:
+		return int64Range(hash>>8, manyFileMinSizeBytes, 32*1024)
+	}
+}
+
+// Keep the many-file ADD payload independent from math/rand implementation changes.
+func manyFileHash(v uint64) uint64 {
+	v += 0x9e3779b97f4a7c15
+	v = (v ^ (v >> 30)) * 0xbf58476d1ce4e5b9
+	v = (v ^ (v >> 27)) * 0x94d049bb133111eb
+	return v ^ (v >> 31)
+}
+
+func int64Range(v uint64, minValue, maxValue int64) int64 {
+	if maxValue <= minValue {
+		return minValue
+	}
+	return minValue + int64(v%uint64(maxValue-minValue+1))
+}
+
+func sumInt64(values []int64) int64 {
+	var total int64
+	for _, value := range values {
+		total += value
+	}
+	return total
+}
+
+func writeTarDir(tw *tar.Writer, name string) error {
+	return tw.WriteHeader(&tar.Header{
+		Name:     name,
+		Typeflag: tar.TypeDir,
+		Mode:     0755,
+	})
+}
+
+func writeTarFile(tw *tar.Writer, name string, size int64, r io.Reader) error {
+	if err := tw.WriteHeader(&tar.Header{
+		Name: name,
+		Mode: 0644,
+		Size: size,
+	}); err != nil {
+		return err
+	}
+
+	_, err := io.CopyN(tw, r, size)
+	return err
+}
+
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	clear(p)
+	return len(p), nil
+}

--- a/util/archiveutil/tar_test.go
+++ b/util/archiveutil/tar_test.go
@@ -1,0 +1,34 @@
+package archiveutil
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestManyFileManifest(t *testing.T) {
+	sizes, err := manyFileSizes()
+	require.NoError(t, err)
+	require.Len(t, sizes, manyFileDirs*manyFilesPerDir)
+	require.Equal(t, int64(536870912), sumInt64(sizes))
+	require.Equal(t, "08c480e41c080b6181e35d1e2b869a1c69457a20a07fce07c39b900bcbef3742", manyFileManifestDigest(sizes))
+}
+
+func manyFileManifestDigest(sizes []int64) string {
+	h := sha256.New()
+	var buf [8]byte
+	fileNum := 0
+	for dirIndex := 0; dirIndex < manyFileDirs; dirIndex++ {
+		for fileIndex := 0; fileIndex < manyFilesPerDir; fileIndex++ {
+			h.Write([]byte(manyFileName(dirIndex, fileIndex)))
+			h.Write([]byte{0})
+			binary.LittleEndian.PutUint64(buf[:], uint64(sizes[fileNum]))
+			h.Write(buf[:])
+			fileNum++
+		}
+	}
+	return fmt.Sprintf("%x", h.Sum(nil))
+}


### PR DESCRIPTION
This makes the many-file tar manifest stable across benchmark runs and pins its size and digest in archiveutil tests.