### PR TITLE
preserve literal gotest output in parser logs

### DIFF
--- a/util/gotest/parse.go
+++ b/util/gotest/parse.go
@@ -65,7 +65,7 @@ func (e *eventHandler) Event(event testjson.TestEvent, _ *testjson.Execution) er
 		return nil
 	}
 	if e.log != nil {
-		log.Printf(event.Output)
+		e.log.Print(event.Output)
 	}
 
 	e.mu.Lock()

--- a/util/gotest/parse_test.go
+++ b/util/gotest/parse_test.go
@@ -1,11 +1,22 @@
 package gotest
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestParseWritesOutputToConfiguredLogger(t *testing.T) {
+	var logs bytes.Buffer
+	_, _, err := Parse(ParseConfig{
+		Stdout: strings.NewReader(`{"Time":"2024-09-03T14:40:54.564305995Z","Action":"output","Package":"pkg","Output":"literal %s\n"}`),
+		Logger: &logs,
+	})
+	require.NoError(t, err)
+	require.Contains(t, logs.String(), "literal %s")
+}
 
 func TestParse(t *testing.T) {
 	res, _, err := Parse(ParseConfig{


### PR DESCRIPTION
Use the configured logger without treating test output as a format string, and cover literal percent output with a regression test.